### PR TITLE
Drain workers before MCR upgrade

### DIFF
--- a/pkg/product/mke/phase/upgrade_mcr.go
+++ b/pkg/product/mke/phase/upgrade_mcr.go
@@ -179,7 +179,7 @@ func (p *UpgradeMCR) upgradeMCR(h *api.Host) error {
 
 			if nodeID != "" {
 				log.Infof("%s: reactivating node %s (%s)", leader, h, nodeID)
-				if err := leader.Exec(leader.Configurer.DockerCommandf("node update --availability drain %s", nodeID)); err != nil {
+				if err := leader.Exec(leader.Configurer.DockerCommandf("node update --availability active %s", nodeID)); err != nil {
 					return fmt.Errorf("%s: reactivation of node %s failed: %w", leader, h, err)
 				}
 			}

--- a/pkg/product/mke/phase/upgrade_mcr.go
+++ b/pkg/product/mke/phase/upgrade_mcr.go
@@ -167,7 +167,15 @@ func (p *UpgradeMCR) upgradeMCR(h *api.Host) error {
 			}
 
 			log.Infof("%s: upgrading container runtime (%s -> %s)", h, h.Metadata.MCRVersion, p.Config.Spec.MCR.Version)
-			return h.Configurer.InstallMCR(h, h.Metadata.MCRInstallScript, p.Config.Spec.MCR)
+			if err := h.Configurer.InstallMCR(h, h.Metadata.MCRInstallScript, p.Config.Spec.MCR); err != nil {
+				return err
+			}
+
+			if nodeID != "" {
+				return h.Exec(h.Configurer.DockerCommandf("node update --availability active %s", nodeID))
+			}
+
+			return nil
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Fixes #354 

Drains worker nodes before upgrading MCR on them and restores to active after.

