### PR TITLE
PRODENG-2797 EL linux preinstalls openssh

### DIFF
--- a/pkg/configurer/enterpriselinux/el.go
+++ b/pkg/configurer/enterpriselinux/el.go
@@ -20,7 +20,7 @@ type Configurer struct {
 
 // InstallMKEBasePackages install all the needed base packages on the host.
 func (c Configurer) InstallMKEBasePackages(h os.Host) error {
-	if err := c.InstallPackage(h, "curl", "socat", "iptables", "iputils", "gzip"); err != nil {
+	if err := c.InstallPackage(h, "curl", "socat", "iptables", "iputils", "gzip", "openssh"); err != nil {
 		return fmt.Errorf("failed to install base packages: %w", err)
 	}
 	return nil


### PR DESCRIPTION
- Rocky/RHEL 9 platforms curl install breaks ssh without adding it to the package list