### PR TITLE
PRODENG-2805 drop segment tokens

### DIFF
--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -83,6 +83,9 @@ func TestIdentifyAnalyticsUser(t *testing.T) {
 }
 
 func TestDefaultClient(t *testing.T) {
+	sc, _ := NewSegmentClient("AAAAAAAAA")
+	defaultClient.AnalyticsClient = sc
+
 	userConfig := user.Config{
 		Name:    "John Doe",
 		Email:   "john.doe@example.org",
@@ -102,6 +105,7 @@ func TestDefaultClient(t *testing.T) {
 	t.Run("Analytics enabled", func(t *testing.T) {
 		old := defaultClient.IsEnabled
 		Enabled(true)
+
 		defer Enabled(old)
 
 		TrackEvent("foobar", nil)


### PR DESCRIPTION
- token removed from code, can be injected at compile time
- if token is empty, disable analytics
- no need for dev/prod token separation, if it is getting injected
- also dropped superfluous logging for when analytics is disabled