### PR TITLE
PRODENG-2808 Fix the create-checksum for checksum verification locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,10 @@ $(RELEASE_FOLDER):
 
 .PHONY: create-checksum
 create-checksum:
-	for f in $(RELEASE_FOLDER)/*; do \
-		$(CHECKSUM) $$f > $$f.sha256; \
-	done
+	cd $(RELEASE_FOLDER) && \
+    for f in ./*; do \
+        $(CHECKSUM) $$f > $$f.sha256; \
+    done
 
 .PHONY: verify-checksum
 verify-checksum:


### PR DESCRIPTION
- Now changing folders into the dist/release folder before generating the sha256 files

https://mirantis.jira.com/browse/PRODENG-2808