### PR TITLE
555 debug reset message conflict fix

### DIFF
--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -29,7 +29,7 @@ func NewResetCommand() *cli.Command {
 				Aliases: []string{"f"},
 			},
 		}...),
-		Before: actions(initLogger, startUpgradeCheck, initAnalytics, checkLicense, initExec, requireForce),
+		Before: actions(initLogger, initAnalytics, checkLicense, initExec, requireForce, startUpgradeCheck),
 		After:  actions(closeAnalytics, upgradeCheckResult),
 		Action: func(ctx *cli.Context) error {
 			start := time.Now()


### PR DESCRIPTION
- launchpad reset command upgrade check now happens after force check, so that the messges don't overlap

Delivers fix for #555 