### PR TITLE
PRODENG-2780 mke output handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@ github-release
 # go mod vendor folder
 vendor
 
-# binaries
-bin/
+# sometimes an example launchpad.yaml is used
+**/launchpad.yaml

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build-release: clean $(RELEASE_FOLDER)
 # the GORELEASER_CURRENT_TAG env var to clarify the version to
 # avoid having the wrong tag version applied
 $(RELEASE_FOLDER):
-	goreleaser build --clean --config=.goreleaser.release.yml
+	SEGMENT_TOKEN=${SEGMENT_TOKEN} goreleaser build --clean --config=.goreleaser.release.yml
 
 .PHONY: create-checksum
 create-checksum:

--- a/examples/terraform/aws-simple/.terraform.lock.hcl
+++ b/examples/terraform/aws-simple/.terraform.lock.hcl
@@ -27,7 +27,6 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/local" {
   version = "2.5.2"
   hashes = [
-    "h1:IyFbOIO6mhikFNL/2h1iZJ6kyN3U00jgkpCLUCThAfE=",
     "h1:JlMZD6nYqJ8sSrFfEAH0Vk/SL8WLZRmFaMUF9PJK5wM=",
     "zh:136299545178ce281c56f36965bf91c35407c11897f7082b3b983d86cb79b511",
     "zh:3b4486858aa9cb8163378722b642c57c529b6c64bfbfc9461d940a84cd66ebea",
@@ -67,7 +66,6 @@ provider "registry.terraform.io/hashicorp/tls" {
   version = "4.0.6"
   hashes = [
     "h1:dYSb3V94K5dDMtrBRLPzBpkMTPn+3cXZ/kIJdtFL+2M=",
-    "h1:n3M50qfWfRSpQV9Pwcvuse03pEizqrmYEryxKky4so4=",
     "zh:10de0d8af02f2e578101688fd334da3849f56ea91b0d9bd5b1f7a243417fdda8",
     "zh:37fc01f8b2bc9d5b055dc3e78bfd1beb7c42cfb776a4c81106e19c8911366297",
     "zh:4578ca03d1dd0b7f572d96bd03f744be24c726bfd282173d54b100fd221608bb",

--- a/pkg/mke/bootstrap.go
+++ b/pkg/mke/bootstrap.go
@@ -1,0 +1,70 @@
+package mke
+
+import (
+	"bufio"
+	"fmt"
+
+	mcclog "github.com/Mirantis/launchpad/pkg/log"
+	common "github.com/Mirantis/launchpad/pkg/product/common/api"
+	"github.com/Mirantis/launchpad/pkg/product/mke/api"
+	"github.com/Mirantis/launchpad/pkg/util/cmdbuffer"
+	"github.com/k0sproject/rig/exec"
+	"github.com/sirupsen/logrus"
+)
+
+// BootstrapConfig configure options for the Bootstrap.
+type BootstrapConfig struct {
+	Config          api.ClusterConfig // REQUIRED: the cluster config is needed
+	Operation       string            // REQUIRED: the MKE bootstrapper operation to run (e.g. install, reset)
+	OperationFlags  common.Flags      // OPTIONAL: flags to pass to the bootstrapper command
+	CleanupDisabled bool              // OPTIONAL: if true, then the bootstrapper container will not be removed
+	ExecOptions     []exec.Option     // OPTIONAL: additional rig exec options to pass down to rig
+}
+
+// Bootstrap a leader host using the MKE bootsrapper as docker run, returning output.
+func Bootstrap(bootconf BootstrapConfig) (string, error) {
+	image := bootconf.Config.Spec.MKE.GetBootstrapperImage()
+	leader := bootconf.Config.Spec.SwarmLeader()
+
+	if mcclog.Debug {
+		bootconf.OperationFlags.AddUnlessExist("--debug")
+	}
+
+	runFlags := common.Flags{"-i", "-v /var/run/docker.sock:/var/run/docker.sock"}
+
+	if !bootconf.CleanupDisabled {
+		runFlags.Add("--rm")
+	}
+
+	if leader.Configurer.SELinuxEnabled(leader) {
+		runFlags.Add("--security-opt label=disable")
+	}
+
+	cmd := leader.Configurer.DockerCommandf("run %s %s %s %s", runFlags.Join(), image, bootconf.Operation, bootconf.OperationFlags.Join())
+	output := ""
+	buf := cmdbuffer.NewBuffer() // an io.Reader which .Read() doesn't eof until .eof() is run. On eof is blocks the .Read
+
+	if wait, err := leader.ExecStreams(cmd, nil, buf, buf, bootconf.ExecOptions...); err != nil {
+		return output, fmt.Errorf("mke bootstrap exec error: %w", err)
+	} else { //nolint: revive
+		go func() {
+			if err := wait.Wait(); err != nil {
+				logrus.Error(err)
+			}
+			buf.EOF()
+		}()
+	}
+
+	sc := bufio.NewScanner(buf)
+	for sc.Scan() {
+		line := sc.Text()
+		output += line
+
+		cmdbuffer.LogrusLine(cmdbuffer.LogrusParseText(line))
+	}
+	if err := sc.Err(); err != nil {
+		return output, fmt.Errorf("mke bootstrap output scan error: %w", err)
+	}
+
+	return output, nil
+}

--- a/pkg/msr/bootstrap.go
+++ b/pkg/msr/bootstrap.go
@@ -1,4 +1,4 @@
-package mke
+package msr
 
 import (
 	"bufio"
@@ -10,6 +10,7 @@ import (
 	"github.com/Mirantis/launchpad/pkg/product/mke/api"
 	"github.com/Mirantis/launchpad/pkg/util/cmdbuffer"
 	"github.com/k0sproject/rig/exec"
+	"github.com/sirupsen/logrus"
 )
 
 // BootstrapOptions configure options for the Bootstrap.
@@ -21,14 +22,19 @@ type BootstrapOptions struct {
 
 // Bootstrap a leader host using the MKE bootsrapper as docker run, returning output.
 func Bootstrap(operation string, config api.ClusterConfig, bootoptions BootstrapOptions) (output string, err error) {
-	image := config.Spec.MKE.GetBootstrapperImage()
-	leader := config.Spec.SwarmLeader()
+	image := config.Spec.MSR.GetBootstrapperImage()
+	leader := config.Spec.MSRLeader()
+	managers := config.Spec.Managers()
 
-	if mcclog.Debug {
+	if checkErr := config.Spec.CheckMKEHealthRemote(managers); err != nil {
+		return "", fmt.Errorf("%s: failed to health check mke, try to set `--ucp-url` installFlag and check connectivity: %w", leader, checkErr)
+	}
+
+	if mcclog.Debug && operation != "images" {
 		bootoptions.OperationFlags.AddUnlessExist("--debug")
 	}
 
-	runFlags := common.Flags{"-i", "-v /var/run/docker.sock:/var/run/docker.sock"}
+	runFlags := common.Flags{"-i"}
 
 	if !bootoptions.CleanupDisabled {
 		runFlags.Add("--rm")
@@ -39,14 +45,16 @@ func Bootstrap(operation string, config api.ClusterConfig, bootoptions Bootstrap
 	}
 
 	cmd := leader.Configurer.DockerCommandf("run %s %s %s %s", runFlags.Join(), image, operation, bootoptions.OperationFlags.Join())
-	buf := cmdbuffer.NewBuffer() // an io.Reader which .Read() doesn't eof until .eof() is run. On eof is blocks the .Read
+
+	buf := cmdbuffer.NewBuffer()
 
 	if wait, err := leader.ExecStreams(cmd, nil, buf, buf, bootoptions.ExecOptions...); err != nil {
-		return output, fmt.Errorf("mke bootstrap exec error: %w", err)
+		return output, fmt.Errorf("msr bootstrap exec error: %w", err)
 	} else { //nolint: revive
 		go func() {
 			if waitErr := wait.Wait(); waitErr != nil {
-				err = errors.Join(err, fmt.Errorf("mke bootstrap %s failure; %w", operation, waitErr))
+				err = errors.Join(err, fmt.Errorf("msr bootstrap %s failure; %w", operation, waitErr))
+				logrus.Error(err)
 			}
 			buf.EOF()
 		}()
@@ -59,11 +67,11 @@ func Bootstrap(operation string, config api.ClusterConfig, bootoptions Bootstrap
 		if le, parseErr := cmdbuffer.LogrusParseText(line); parseErr == nil {
 			// output was logrus, so pipe it to launchpad logrus
 			output += fmt.Sprintf("%s\n", le.Msg)
-			le.Msg = fmt.Sprintf("MKE %s: %s", operation, le.Msg)
+			le.Msg = fmt.Sprintf("MSR %s: %s", operation, le.Msg)
 			cmdbuffer.LogrusLine(le)
 
 			if le.Level == "fatal" {
-				err = errors.Join(err, fmt.Errorf("mke bootstrap %s failure; %s", operation, le.Msg)) //nolint
+				err = errors.Join(err, fmt.Errorf("msr bootstrap %s failure; %s", operation, le.Msg)) //nolint
 			}
 		} else {
 			// output line was not logrus, so just output it
@@ -72,8 +80,8 @@ func Bootstrap(operation string, config api.ClusterConfig, bootoptions Bootstrap
 		}
 	}
 	if scanErr := scanner.Err(); scanErr != nil {
-		err = errors.Join(err, fmt.Errorf("mke bootstrap output scan error: %w", scanErr))
+		err = errors.Join(err, fmt.Errorf("msr bootstrap output scan error: %w", scanErr)) //nolint
 	}
 
-	return output, err
+	return output, nil
 }

--- a/pkg/util/cmdbuffer/buffer.go
+++ b/pkg/util/cmdbuffer/buffer.go
@@ -1,0 +1,99 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// copied from https://cs.opensource.google/go/x/crypto/+/master:ssh/buffer.go
+
+package cmdbuffer
+
+import (
+	"io"
+	"sync"
+)
+
+// buffer provides a linked list buffer for data exchange
+// between producer and consumer. Theoretically the buffer is
+// of unlimited capacity as it does no allocation of its own.
+type buffer struct {
+	// protects concurrent access to head, tail and closed
+	*sync.Cond
+
+	head *element // the buffer that will be read first
+	tail *element // the buffer that will be read last
+
+	closed bool
+}
+
+// An element represents a single link in a linked list.
+type element struct {
+	buf  []byte
+	next *element
+}
+
+// NewBuffer returns an empty buffer that does not EOF until it is closed.
+func NewBuffer() *buffer {
+	e := new(element)
+	b := &buffer{
+		Cond: sync.NewCond(new(sync.Mutex)),
+		head: e,
+		tail: e,
+	}
+	return b
+}
+
+// EOF closes the buffer. Reads from the buffer once all
+// the data has been consumed will receive io.EOF.
+func (b *buffer) EOF() {
+	b.Cond.L.Lock()
+	b.closed = true
+	b.Cond.Signal()
+	b.Cond.L.Unlock()
+}
+
+// Write makes buf available for Read to receive.
+// buf must not be modified after the call to write.
+func (b *buffer) Write(buf []byte) (int, error) {
+	b.Cond.L.Lock()
+	e := &element{buf: buf}
+	b.tail.next = e
+	b.tail = e
+	b.Cond.Signal()
+	b.Cond.L.Unlock()
+	return len(buf), nil
+}
+
+// Read reads data from the internal buffer in buf.  Reads will block
+// if no data is available, or until the buffer is closed.
+func (b *buffer) Read(buf []byte) (n int, err error) {
+	b.Cond.L.Lock()
+	defer b.Cond.L.Unlock()
+
+	for len(buf) > 0 {
+		// if there is data in b.head, copy it
+		if len(b.head.buf) > 0 {
+			r := copy(buf, b.head.buf)
+			buf, b.head.buf = buf[r:], b.head.buf[r:]
+			n += r
+			continue
+		}
+		// if there is a next buffer, make it the head
+		if len(b.head.buf) == 0 && b.head != b.tail {
+			b.head = b.head.next
+			continue
+		}
+
+		// if at least one byte has been copied, return
+		if n > 0 {
+			break
+		}
+
+		// if nothing was read, and there is nothing outstanding
+		// check to see if the buffer is closed.
+		if b.closed {
+			err = io.EOF
+			break
+		}
+		// out of buffers, wait for producer
+		b.Cond.Wait()
+	}
+	return n, err
+}

--- a/pkg/util/cmdbuffer/buffer_test.go
+++ b/pkg/util/cmdbuffer/buffer_test.go
@@ -40,7 +40,7 @@ func Test_BufferScanner(t *testing.T) {
 
 	sc := bufio.NewScanner(buf)
 
-	for i:=0; i<13; i++ {
+	for i := 0; i < 13; i++ {
 		expected := fmt.Sprintf("message-%d", i)
 
 		if !sc.Scan() {
@@ -53,12 +53,12 @@ func Test_BufferScanner(t *testing.T) {
 		if expected != got {
 			t.Errorf("got wrong message: '%s' != '%s'", expected, got)
 		}
-		
+
 	}
 
 	if sc.Scan() {
 		t.Error("buffer scanned more lines than expected")
-	}	
+	}
 	if err := sc.Err(); err != nil {
 		t.Error(err)
 	}

--- a/pkg/util/cmdbuffer/buffer_test.go
+++ b/pkg/util/cmdbuffer/buffer_test.go
@@ -1,0 +1,65 @@
+package cmdbuffer_test
+
+import (
+	"bufio"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Mirantis/launchpad/pkg/util/cmdbuffer"
+)
+
+func Test_BufferScanner(t *testing.T) {
+
+	buf := cmdbuffer.NewBuffer()
+
+	go func() {
+		buf.Write([]byte("message-0\n"))
+		buf.Write([]byte("message-1\n"))
+		buf.Write([]byte("message-2\n"))
+		time.Sleep(10 * time.Microsecond)
+		buf.Write([]byte("mes"))
+		time.Sleep(200 * time.Microsecond)
+		buf.Write([]byte("sage-3\n"))
+		buf.Write([]byte("message-4\n"))
+		buf.Write([]byte("message-5\n"))
+		time.Sleep(1000 * time.Microsecond)
+		buf.Write([]byte("message-6\n"))
+		buf.Write([]byte("message-7\n"))
+		buf.Write([]byte("message-8\n"))
+		time.Sleep(10 * time.Microsecond)
+		buf.Write([]byte("message-9\n"))
+		buf.Write([]byte("message-10\n"))
+		buf.Write([]byte("message-11\n"))
+		time.Sleep(200 * time.Microsecond)
+		buf.Write([]byte("message-12\n"))
+		time.Sleep(10 * time.Microsecond)
+
+		buf.EOF()
+	}()
+
+	sc := bufio.NewScanner(buf)
+
+	for i:=0; i<13; i++ {
+		expected := fmt.Sprintf("message-%d", i)
+
+		if !sc.Scan() {
+			t.Error("unexpected scan failure")
+			continue
+		}
+
+		got := sc.Text()
+
+		if expected != got {
+			t.Errorf("got wrong message: '%s' != '%s'", expected, got)
+		}
+		
+	}
+
+	if sc.Scan() {
+		t.Error("buffer scanned more lines than expected")
+	}	
+	if err := sc.Err(); err != nil {
+		t.Error(err)
+	}
+}

--- a/pkg/util/cmdbuffer/logrus.go
+++ b/pkg/util/cmdbuffer/logrus.go
@@ -1,0 +1,42 @@
+package cmdbuffer
+
+import (
+	"regexp"
+
+	"github.com/sirupsen/logrus"
+)
+
+// LogEntry intrepretation of a logrus record
+type LogEntry struct {
+	Level string `json:"level"` 
+	Time  string `json:"time"`
+	Msg   string `json:"msg"`
+}
+
+
+// a regex pattern for matching lines
+var logPattern = regexp.MustCompile(`time="(?P<time>\S*)"\slevel=(?P<level>\S*)\smsg="(?<msg>.*)"`)
+// LogrusParseText parse a text logrus entry into its parts
+func LogrusParseText(line string) LogEntry {
+	m := logPattern.FindStringSubmatch(line)
+
+	return LogEntry{
+		Time: m[1],
+		Level: m[2],
+		Msg: m[3],
+	}
+}
+
+// LogrusLine proxy log a Logrus entry
+func LogrusLine(le LogEntry) {
+	switch (le.Level) {
+	case "debug":
+		logrus.Debug(le.Msg)
+	case "warn":
+		logrus.Warn(le.Msg)
+	case "error":
+		logrus.Error(le.Msg)
+	case "info":
+		logrus.Info(le.Msg)
+	}
+}

--- a/pkg/util/cmdbuffer/logrus.go
+++ b/pkg/util/cmdbuffer/logrus.go
@@ -1,42 +1,65 @@
 package cmdbuffer
 
 import (
+	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
 
-// LogEntry intrepretation of a logrus record
+var ErrNotALogRusLine = fmt.Errorf("line was not a logrus entry")
+
+// LogEntry interpretation of a logrus record.
 type LogEntry struct {
-	Level string `json:"level"` 
+	Level string `json:"level"`
 	Time  string `json:"time"`
 	Msg   string `json:"msg"`
 }
 
-
-// a regex pattern for matching lines
+// a regex pattern for matching lines.
 var logPattern = regexp.MustCompile(`time="(?P<time>\S*)"\slevel=(?P<level>\S*)\smsg="(?<msg>.*)"`)
-// LogrusParseText parse a text logrus entry into its parts
-func LogrusParseText(line string) LogEntry {
-	m := logPattern.FindStringSubmatch(line)
 
-	return LogEntry{
-		Time: m[1],
-		Level: m[2],
-		Msg: m[3],
+// LogrusParseText parse a text logrus entry into its parts.
+func LogrusParseText(line string) (LogEntry, error) {
+	matches := logPattern.FindStringSubmatch(line)
+
+	logentry := LogEntry{
+		Time: time.Now().Format(time.RFC3339),
 	}
+	var logerror error
+
+	if matches == nil {
+		logentry.Level = "info"
+		logentry.Msg = line
+		logerror = ErrNotALogRusLine
+	} else {
+		if len(matches) > 3 {
+			logentry.Msg = matches[3]
+		}
+		if len(matches) > 2 {
+			logentry.Level = matches[2]
+		}
+		if len(matches) > 1 {
+			logentry.Time = matches[1]
+		}
+	}
+
+	return logentry, logerror
 }
 
-// LogrusLine proxy log a Logrus entry
-func LogrusLine(le LogEntry) {
-	switch (le.Level) {
+// LogrusLine proxy log a Logrus entry.
+func LogrusLine(logentry LogEntry) {
+	switch logentry.Level {
 	case "debug":
-		logrus.Debug(le.Msg)
+		logrus.Debug(logentry.Msg)
 	case "warn":
-		logrus.Warn(le.Msg)
+		logrus.Warn(logentry.Msg)
 	case "error":
-		logrus.Error(le.Msg)
-	case "info":
-		logrus.Info(le.Msg)
+		logrus.Error(logentry.Msg)
+	case "fatal": // you should handle the exception yourself
+		logrus.Error(logentry.Msg)
+	default: // includes "info"
+		logrus.Info(logentry.Msg)
 	}
 }

--- a/pkg/util/cmdbuffer/logrus_test.go
+++ b/pkg/util/cmdbuffer/logrus_test.go
@@ -1,0 +1,22 @@
+package cmdbuffer_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Mirantis/launchpad/pkg/util/cmdbuffer"
+)
+
+func TestParseTest(t *testing.T) {
+	el1 := cmdbuffer.LogEntry{
+		Time:  "2025-01-30T17:33:27Z",
+		Level: "info",
+		Msg:   "message",
+	}
+
+	l1 := cmdbuffer.LogrusParseText(fmt.Sprintf("time=\"%s\" level=%s msg=\"%s\"\n", el1.Time, el1.Level, el1.Msg))
+
+	if el1 != l1 {
+		t.Errorf("line parse failed: %+v != %+v", el1, l1)
+	}	
+}

--- a/pkg/util/cmdbuffer/logrus_test.go
+++ b/pkg/util/cmdbuffer/logrus_test.go
@@ -1,22 +1,49 @@
 package cmdbuffer_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/Mirantis/launchpad/pkg/util/cmdbuffer"
 )
 
-func TestParseTest(t *testing.T) {
+func TestParseTestLogrusTxt(t *testing.T) {
 	el1 := cmdbuffer.LogEntry{
 		Time:  "2025-01-30T17:33:27Z",
 		Level: "info",
 		Msg:   "message",
 	}
 
-	l1 := cmdbuffer.LogrusParseText(fmt.Sprintf("time=\"%s\" level=%s msg=\"%s\"\n", el1.Time, el1.Level, el1.Msg))
+	l1, err := cmdbuffer.LogrusParseText(fmt.Sprintf("time=\"%s\" level=%s msg=\"%s\"\n", el1.Time, el1.Level, el1.Msg))
 
 	if el1 != l1 {
 		t.Errorf("line parse failed: %+v != %+v", el1, l1)
-	}	
+	}
+	if err != nil {
+		t.Errorf("line parse gave unexpected error: %v", err)
+	}
+}
+
+func TestParseTestNotLogrus(t *testing.T) {
+	el1 := cmdbuffer.LogEntry{
+		Time:  "2025-01-30T17:33:27Z",
+		Level: "info",
+		Msg:   "message",
+	}
+
+	l1, err := cmdbuffer.LogrusParseText("message")
+
+	if el1.Level != l1.Level {
+		t.Errorf("line parse failed level: %+v != %+v", el1, l1)
+	}
+	if el1.Msg != l1.Msg {
+		t.Errorf("line parse failed msg: %+v != %+v", el1, l1)
+	}
+	if err == nil {
+		t.Errorf("line parse did not give expected error")
+	}
+	if !errors.Is(err, cmdbuffer.ErrNotALogRusLine) {
+		t.Errorf("line parse gave the wrong error: %v", err)
+	}
 }


### PR DESCRIPTION
Refactor how we handle the output from the MKE and MSR docker run bootstrapping. Primarily focused on better consuming log messages from the bootstrappers natively into launchpad log messages (proper log level handling, better message handling,) but also de-duping the docker runs themselves

- new buffer tooling that can act like an output logging buffer for rig exec 
- new buffer line handling for logrus output (interprets command output as txt logrus output so that it can be consumed as launchpad logrus output)
- new MKE and MSR functions for running the respective bootstrapper on a cluster, with better output handling using the new buffer tool to prevent embedded logrus
- install, upgrade, reset and image pull phases use the new bootstrapper functions (reduce redundancy).

The command buffer may actually be something that the k0sproject/rig project is interested in.