### PR TITLE
530 host mcr upgrade skip

### DIFF
--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -29,7 +29,7 @@ func NewResetCommand() *cli.Command {
 				Aliases: []string{"f"},
 			},
 		}...),
-		Before: actions(initLogger, startUpgradeCheck, initAnalytics, checkLicense, initExec, requireForce),
+		Before: actions(initLogger, initAnalytics, checkLicense, initExec, requireForce, startUpgradeCheck),
 		After:  actions(closeAnalytics, upgradeCheckResult),
 		Action: func(ctx *cli.Context) error {
 			start := time.Now()

--- a/pkg/product/mke/api/host.go
+++ b/pkg/product/mke/api/host.go
@@ -78,7 +78,8 @@ type Host struct {
 	Hooks            common.Hooks      `yaml:"hooks,omitempty" validate:"dive,keys,oneof=apply reset,endkeys,dive,keys,oneof=before after,endkeys,omitempty"`
 	ImageDir         string            `yaml:"imageDir,omitempty"`
 	SudoDocker       bool              `yaml:"sudodocker"`
-	SudoOverride     bool              `yaml:"sudooverride"` // some customers can't allow the default rig connection sudo detection
+	SudoOverride     bool              `yaml:"sudooverride"`   // some customers can't allow the default rig connection sudo detection
+	MCRUpgradeSkip   bool              `yaml:"mcrupgradeskip"` // don't upgrade this host when upgraing MCR (to allow upgrades in batches
 
 	Metadata    *HostMetadata  `yaml:"-"`
 	MSRMetadata *MSRMetadata   `yaml:"-"`

--- a/pkg/product/mke/phase/upgrade_mcr.go
+++ b/pkg/product/mke/phase/upgrade_mcr.go
@@ -30,6 +30,10 @@ func (p *UpgradeMCR) HostFilterFunc(h *api.Host) bool {
 	if h.Metadata.MCRVersion != p.Config.Spec.MCR.Version {
 		return true
 	}
+	if h.MCRUpgradeSkip {
+		log.Warnf("%s: MCR Upgrade configuration for host instructs launchpad to skip upgrading this host.", h)
+		return false
+	}
 	if p.ForceUpgrade && !h.Metadata.MCRInstalled {
 		log.Warnf("%s: MCR version is already %s but attempting an upgrade anyway because --force-upgrade was given", h, h.Metadata.MCRVersion)
 		return true

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+REPO_NAME="${REPO_NAME:-launchpad}"
+REPO_USER="${REPO_USER:-Mirantis}"
+
 if [ -z "${TAG_NAME}" ]; then
   echo "TAG_NAME not set"
   exit 1
@@ -11,7 +14,7 @@ artifacts=$(find ${artifact_path}/* -exec basename {} \;)
 echo "Releasing with:"
 for artifact in ${artifacts}; do echo "- ${artifact}"; done
 
-curl -L https://github.com/github-release/github-release/releases/download/v0.8.1/linux-amd64-github-release.bz2 > ./github-release.bz2
+curl -L https://github.com/github-release/github-release/releases/download/v0.10.0/linux-amd64-github-release.bz2 > ./github-release.bz2
 bunzip2 -f ./github-release.bz2
 chmod +x ./github-release
 
@@ -21,24 +24,24 @@ else
   releaseopt=""
 fi
 
-echo "Creating release named ${TAG_NAME} in MCC repo"
+echo "Creating release named ${TAG_NAME} in ${REPO_NAME} repo"
 
 ./github-release release \
   $releaseopt \
-  --user Mirantis \
-  --repo mcc \
+  --user "${REPO_USER}" \
+  --repo "${REPO_NAME}" \
   --tag "${TAG_NAME}" \
   --name "${TAG_NAME}"
 
 sleep 10
 
-echo "Uploading the artifacts to ${TAG_NAME} in MCC repo"
+echo "Uploading the artifacts to ${TAG_NAME} in ${REPO_NAME} repo"
 
 for artifact in ${artifacts}
 do
    ./github-release upload \
-    --user Mirantis \
-    --repo mcc \
+    --user "${REPO_USER}" \
+    --repo "${REPO_NAME}" \
     --tag "${TAG_NAME}" \
     --name "${artifact}" \
     --file "${artifact_path}/${artifact}"


### PR DESCRIPTION
- New host boolean flag MCRSkipUpgrade that make the MCR upgrade skip - allows MCR upgrades in batches so that workload safety can be managed by the operator