### PR TITLE
ENGINE-773  Add `additionalRuntimes` param for MCR

### DIFF
--- a/pkg/configurer/linux.go
+++ b/pkg/configurer/linux.go
@@ -58,7 +58,14 @@ func (c LinuxConfigurer) InstallMCR(h os.Host, scriptPath string, engineConfig c
 		}
 	}()
 
-	cmd := fmt.Sprintf("DOCKER_URL=%s CHANNEL=%s VERSION=%s bash %s", engineConfig.RepoURL, engineConfig.Channel, engineConfig.Version, escape.Quote(installer))
+	envs := fmt.Sprintf("DOCKER_URL=%s CHANNEL=%s VERSION=%s ", engineConfig.RepoURL, engineConfig.Channel, engineConfig.Version)
+	if engineConfig.AdditionalRuntimes != "" {
+		envs += fmt.Sprintf("ADDITIONAL_RUNTIMES=%s ", engineConfig.AdditionalRuntimes)
+	}
+	if engineConfig.DefaultRuntime != "" {
+		envs += fmt.Sprintf("DEFAULT_RUNTIME=%s ", engineConfig.DefaultRuntime)
+	}
+	cmd := envs + fmt.Sprintf("bash %s", escape.Quote(installer))
 
 	log.Infof("%s: running installer", h)
 

--- a/pkg/product/common/api/mcr_config.go
+++ b/pkg/product/common/api/mcr_config.go
@@ -21,6 +21,8 @@ type DockerDaemonConfig struct {
 type MCRConfig struct {
 	Version                     string   `yaml:"version"`
 	RepoURL                     string   `yaml:"repoURL,omitempty"`
+	AdditionalRuntimes          string   `yaml:"additionalRuntimes,omitempty"`
+	DefaultRuntime              string   `yaml:"defaultRuntime,omitempty"`
 	InstallURLLinux             string   `yaml:"installURLLinux,omitempty"`
 	InstallScriptRemoteDirLinux string   `yaml:"installScriptRemoteDirLinux,omitempty"`
 	InstallURLWindows           string   `yaml:"installURLWindows,omitempty"`


### PR DESCRIPTION
## What type of PR is this?
- [x] :rocket:  New feature / improvement

## What this PR does / why we need it:
Add 2 additional flags for MCR installation:
- `additionalRuntimes` - allow to specify additional runtimes during MCR installation (default is empty, example: "crun,runc")

## Issue(s) this PR fixes:
- [x] Add JIRA issue to the PR title
- [x] Add link(s) to the JIRA issue(s) here: https://mirantis.jira.com/browse/ENGINE-773

## Release branch(es):
- [x] Add release branch name to the PR title (omit if it's `master`)
- [x] This PR is the main PR, no cherry-picks are necessary

## How has this been tested? (NOT optional)
Deploy MKE on top MCR w/ these new flags.

```
apiVersion: launchpad.mirantis.com/mke/v1.4
kind: mke
metadata:
  name: mcr
spec:
  hosts:
  - role: manager
    ssh:
      user: ubuntu
      address: <ip>
      keyPath: <key>
      mcrConfig:
       runtimes:
        crun:
          path: /usr/bin/crun
       default-runtime: crun
  mcr:
    version: 25.0.9m1
    channel: stable-25.0
    repoURL: https://repos.mirantis.com
    installURLLinux: https://mcr-ci-artifacts.s3.us-west-2.amazonaws.com/aepifanov/install.sh
    additionalRuntimes: crun
  mke:
    version: 3.8.2
    installFlags:
    - --force-minimums
```
And checked the /etc/docker/daemon.json:
```
root@ip-172-31-27-227:~# cat /etc/docker/daemon.json
{
  "runtimes": {
    "crun": {
      "path": "/usr/bin/crun"
    }
  },
  "default-runtime": "crun"
}
```
And that all containers have `crun` Runtime:
```
root@ip-172-31-27-227:~# docker ps | grep -v CONTAINER | awk '{print $1}' | xargs docker inspect | grep '"Runtime": '
            "Runtime": "crun",
            "Runtime": "crun",
            "Runtime": "crun",
            "Runtime": "crun",
```