### PR TITLE
Helm test fix

### DIFF
--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -3,7 +3,6 @@ package helm
 import (
 	"testing"
 
-	"github.com/Mirantis/launchpad/pkg/constant"
 	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -11,15 +10,15 @@ import (
 
 func TestChartNeedsUpgrade(t *testing.T) {
 	h := NewHelmTestClient(t)
-	rd, _ := InstallRethinkDBOperatorChart(t, h)
+	rd, _ := InstallCertManagerChart(t, h)
 
-	rdbOperatorVersion := rd.Version
+	rdChartVersion := rd.Version
 
 	testCases := []string{
 		// ChartNeedsUpgrade returns true if the version is DIFFERENT from
-		// the installed one, so anything but rdbOperatorVersion should return
+		// the installed one, so anything but Version should return
 		// true. It's written this way to support downgrades.
-		rdbOperatorVersion,
+		rdChartVersion,
 		"1.0.0",
 		"1.0.1",
 		"1.0.100",
@@ -36,12 +35,12 @@ func TestChartNeedsUpgrade(t *testing.T) {
 		vers, err := version.NewVersion(tc)
 		require.NoError(t, err)
 
-		actual, err := h.ChartNeedsUpgrade(constant.RethinkDBOperator, vers)
+		actual, err := h.ChartNeedsUpgrade(rd.ReleaseName, vers)
 		if assert.NoError(t, err) {
-			if tc == rdbOperatorVersion {
-				assert.False(t, actual, "version: %s does match current version: %s", tc, rdbOperatorVersion)
+			if tc == rdChartVersion {
+				assert.False(t, actual, "version: %s does match current version: %s", tc, rdChartVersion)
 			} else {
-				assert.True(t, actual, "version: %s does not match current version: %s", tc, rdbOperatorVersion)
+				assert.True(t, actual, "version: %s does not match current version: %s", tc, rdChartVersion)
 			}
 		}
 	}

--- a/pkg/helm/testutil.go
+++ b/pkg/helm/testutil.go
@@ -77,16 +77,49 @@ func NewHelmTestClient(t *testing.T, options ...HelmTestClientOption) *Helm {
 	}
 }
 
+
+
+// InstallCertManagerChart installs cert-manager
+// to use as a chart to query for testing purposes and returns the
+// ReleaseDetails for the chart as well as a function to uninstall the chart.
+func InstallCertManagerChart(t *testing.T, h *Helm) (ReleaseDetails, func()) {
+	t.Helper()
+
+	rd := ReleaseDetails{
+		ChartName:   "cert-manager",
+		ReleaseName: "cert-manager",
+		RepoURL:     "https://charts.jetstack.io",
+		Version:     "1.10.0",
+	}
+
+	_, err := h.Upgrade(context.Background(), &Options{
+		ReleaseDetails: rd, Timeout: ptr.To(DefaultTimeout),
+	})
+	require.NoError(t, err)
+
+	uninstallFunc := func() {
+		err := h.Uninstall(&Options{
+			ReleaseDetails: rd, Timeout: ptr.To(DefaultTimeout),
+		})
+		require.NoError(t, err)
+	}
+
+	rd.Installed = true
+
+	return rd, uninstallFunc
+}
+
 // InstallRethinkDBOperatorChart installs rethinkdb-operator
 // to use as a chart to query for testing purposes and returns the
 // ReleaseDetails for the chart as well as a function to uninstall the chart.
+// @NOTE not currently tested
 func InstallRethinkDBOperatorChart(t *testing.T, h *Helm) (ReleaseDetails, func()) {
 	t.Helper()
 
 	rd := ReleaseDetails{
-		ChartName:   constant.RethinkDBOperator,
+		ChartName:   "oci://registry.mirantis.com/rethinkdb/helm/rethindb-operator",
 		ReleaseName: constant.RethinkDBOperator,
-		RepoURL:     "https://registry.mirantis.com/charts/rethinkdb/rethinkdb-operator",
+		RepoURL:     "",
 		Version:     "1.0.0",
 	}
 

--- a/pkg/helm/uninstall_test.go
+++ b/pkg/helm/uninstall_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestUninstall(t *testing.T) {
 	h := NewHelmTestClient(t)
-	rd, _ := InstallRethinkDBOperatorChart(t, h)
+	rd, _ := InstallCertManagerChart(t, h)
 
 	err := h.Uninstall(&Options{
 		ReleaseDetails: rd,

--- a/pkg/helm/upgrade_test.go
+++ b/pkg/helm/upgrade_test.go
@@ -12,7 +12,7 @@ func TestUpgrade(t *testing.T) {
 	h := NewHelmTestClient(t)
 
 	t.Run("Upgrade success", func(t *testing.T) {
-		rd, uninstallFunc := InstallRethinkDBOperatorChart(t, h)
+		rd, uninstallFunc := InstallCertManagerChart(t, h)
 		t.Cleanup(uninstallFunc)
 		rd.Values = map[string]interface{}{
 			"controllerManager": map[string]interface{}{
@@ -33,12 +33,12 @@ func TestUpgrade(t *testing.T) {
 	})
 
 	t.Run("Upgrade, reuse values", func(t *testing.T) {
-		rd, uninstallFunc := InstallRethinkDBOperatorChart(t, h)
+		rd, uninstallFunc := InstallCertManagerChart(t, h)
 		t.Cleanup(uninstallFunc)
 
 		rd.Values = map[string]interface{}{
-			"rethinkdb": map[string]interface{}{
-				"name": "cooler-rethinkdb",
+			"image": map[string]interface{}{
+				"tag": "1.2.3",
 			},
 		}
 
@@ -51,7 +51,7 @@ func TestUpgrade(t *testing.T) {
 			assert.Equal(t, rd.ChartName, rel.Chart.Metadata.Name)
 			// ReuseValues should not change the values, but reuse the previous
 			// ones.
-			assert.NotEqual(t, "cooler-rethinkdb", rel.Chart.Values["rethinkdb"].(map[string]interface{})["name"])
+			assert.NotEqual(t, "1.2.3", rel.Chart.Values["image"].(map[string]interface{})["tag"])
 			assert.ObjectsAreEqualValues(rd.Values, rel.Chart.Values)
 		}
 	})


### PR DESCRIPTION
- rethinkdb operator moved to an oci chart, but the tests don't support it.
- moved the testing to use the cert-manager chart

TODO will come back and get the helm tooling to handle oci charts in the future