### PR TITLE
PRODENG-2962 allow separate auth for MKE/MSR regs

### DIFF
--- a/pkg/docker/envauth.go
+++ b/pkg/docker/envauth.go
@@ -1,0 +1,31 @@
+package docker
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+var (
+	ErrNoEnvPasswordsFound = errors.New("no mathing Env U/P found")
+	ErrMissingPassword     = errors.New("env username was missing matching Env password")
+)
+
+// DiscoverEnvLogin if there are any env based logins, based on a list of ENV variable prefixes.
+func DiscoverEnvLogin(prefixes []string) (user, pass string, err error) {
+	for _, prefix := range prefixes {
+		userEnv := fmt.Sprintf("%sUSERNAME", prefix)
+		passEnv := fmt.Sprintf("%sPASSWORD", prefix)
+
+		if user = os.Getenv(userEnv); user != "" {
+			pass = os.Getenv(passEnv)
+			if pass == "" {
+				err = fmt.Errorf("%w; %s username env variable did not have matching password variable %s", ErrMissingPassword, userEnv, passEnv)
+			}
+			return
+		}
+	}
+	// if there were no matching vars, then we are not supposed to do a login
+	err = ErrNoEnvPasswordsFound
+	return
+}

--- a/pkg/docker/envauth_test.go
+++ b/pkg/docker/envauth_test.go
@@ -1,0 +1,57 @@
+package docker_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Mirantis/launchpad/pkg/docker"
+	"github.com/stretchr/testify/require"
+)
+
+// Be careful here as envs set in one test may still be set in the next test
+
+func Test_EnvAuthTesting_Simple(t *testing.T) {
+	os.Setenv("REGISTRY_USERNAME", "myuser")
+	os.Setenv("REGISTRY_PASSWORD", "mypass")
+
+	u, p, err := docker.DiscoverEnvLogin([]string{"REGISTRY_"})
+
+	require.Equal(t, "myuser", u, "wrong username discovered")
+	require.Equal(t, "mypass", p, "wrong password discovered")
+	require.NoError(t, err, "unexpected error returned")
+}
+
+func Test_EnvAuthTesting_MissingPassword(t *testing.T) {
+	os.Setenv("MISSINGPASSWORD_USERNAME", "myuser")
+
+	_, _, err := docker.DiscoverEnvLogin([]string{"MISSINGPASSWORD_"})
+	require.Error(t, err, "expected error not returned for missing password")
+	require.ErrorIs(t, err, docker.ErrMissingPassword, "wrong error returned for missing pass envs")
+}
+
+func Test_EnvAuthTesting_MissingEnv(t *testing.T) {
+	_, _, err := docker.DiscoverEnvLogin([]string{"NOTSET_"})
+	require.Error(t, err, "expected error not returned for missing password")
+	require.ErrorIs(t, err, docker.ErrNoEnvPasswordsFound, "wrong error returned for missing envs")
+}
+
+func Test_EnvAuthTesting_Multiple(t *testing.T) {
+	os.Setenv("MULTIPLE_ONE_USERNAME", "userone")
+	os.Setenv("MULTIPLE_ONE_PASSWORD", "passone")
+	os.Setenv("MULTIPLE_TWO_USERNAME", "usertwo")
+	os.Setenv("MULTIPLE_TWO_PASSWORD", "passtwo")
+
+	u1, p1, err1 := docker.DiscoverEnvLogin([]string{"MULTIPLE_ONE_", "MULTIPLE_TWO_"})
+	require.Equal(t, "userone", u1, "wrong username discovered")
+	require.Equal(t, "passone", p1, "wrong password discovered")
+	require.NoError(t, err1, "unexpected error returned")
+
+	u2, p2, err2 := docker.DiscoverEnvLogin([]string{"DOESNOTEXIST_", "MULTIPLE_ONE_"})
+	require.Equal(t, "userone", u2, "wrong username discovered")
+	require.Equal(t, "passone", p2, "wrong password discovered")
+	require.NoError(t, err2, "unexpected error returned")
+
+	_, _, err := docker.DiscoverEnvLogin([]string{"NOTSET1_", "NOTSET2_"})
+	require.Error(t, err, "expected error not returned for missing password")
+	require.ErrorIs(t, docker.ErrNoEnvPasswordsFound, err, "wrong error returned for missing envs")
+}

--- a/pkg/docker/repo.go
+++ b/pkg/docker/repo.go
@@ -1,0 +1,16 @@
+package docker
+
+import (
+	"strings"
+)
+
+// CompareRepos to repo registries to see if they are the same.
+func CompareRepos(one, two string) bool {
+	if one == "" {
+		one = "docker.io"
+	}
+	if two == "" {
+		two = "docker.io"
+	}
+	return strings.Split(strings.ToLower(one), "/")[0] == strings.Split(strings.ToLower(two), "/")[0]
+}

--- a/pkg/docker/repo_test.go
+++ b/pkg/docker/repo_test.go
@@ -1,0 +1,23 @@
+package docker_test
+
+import (
+	"testing"
+
+	"github.com/Mirantis/launchpad/pkg/docker"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_CompareRepos(t *testing.T) {
+	require.True(t, docker.CompareRepos("registry.mirantis.com/mirantis", "registry.mirantis.com/mirantis"))
+	require.False(t, docker.CompareRepos("registry.mirantis.com/mirantis", "registry.ci.mirantis.com/mirantiseng"))
+
+	require.True(t, docker.CompareRepos("", ""))
+
+	// some case handling
+	require.True(t, docker.CompareRepos("registry.Mirantis.com/mirantis", "registry.mirantis.com/Mirantis"))
+	require.True(t, docker.CompareRepos("Registry.mirantis.com/mirantis", "registry.mirantis.com/mirantis"))
+	require.True(t, docker.CompareRepos("registry.mirantis.com/mirantis", "registry.mirantis.com/Mirantis"))
+
+	// the docker.io special case
+	require.True(t, docker.CompareRepos("docker.io/mirantis", ""))
+}

--- a/pkg/helm/testutil.go
+++ b/pkg/helm/testutil.go
@@ -77,8 +77,6 @@ func NewHelmTestClient(t *testing.T, options ...HelmTestClientOption) *Helm {
 	}
 }
 
-
-
 // InstallCertManagerChart installs cert-manager
 // to use as a chart to query for testing purposes and returns the
 // ReleaseDetails for the chart as well as a function to uninstall the chart.

--- a/pkg/product/mke/api/configurer.go
+++ b/pkg/product/mke/api/configurer.go
@@ -22,7 +22,7 @@ type HostConfigurer interface {
 	MCRConfigPath() string
 	InstallMCR(os.Host, string, common.MCRConfig) error
 	UninstallMCR(os.Host, string, common.MCRConfig) error
-	DockerCommandf(template string, args ...interface{}) string
+	DockerCommandf(template string, args ...any) string
 	RestartMCR(os.Host) error
 	AuthenticateDocker(h os.Host, user, pass, repo string) error
 	LocalAddresses(os.Host) ([]string, error)

--- a/pkg/product/mke/api/host.go
+++ b/pkg/product/mke/api/host.go
@@ -132,7 +132,6 @@ func (h *Host) AuthorizeDocker() error {
 
 func (h *Host) sudoCommandOptions(cmd string, opts []exec.Option) []exec.Option {
 	if h.IsSudoCommand(cmd) {
-		log.Debugf("%s: Exec is getting SUDOed as the command is in the host sudo list: %s", h, cmd)
 		opts = append(opts, exec.Sudo(h))
 	}
 	return opts

--- a/pkg/product/mke/phase/authenticate_docker.go
+++ b/pkg/product/mke/phase/authenticate_docker.go
@@ -1,22 +1,71 @@
 package phase
 
 import (
+	"errors"
 	"fmt"
-	"os"
+	"strings"
 
+	"github.com/Mirantis/launchpad/pkg/docker"
 	"github.com/Mirantis/launchpad/pkg/phase"
 	"github.com/Mirantis/launchpad/pkg/product/mke/api"
+	log "github.com/sirupsen/logrus"
 )
+
+const (
+	AuthEnvPrefixGeneric = "REGISTRY_"
+	AuthEnvPrefixMke     = "MKE_REGISTRY_"
+	AuthEnvPrefixMsr     = "MSR_REGISTRY_"
+)
+
+type loginConfig struct {
+	username string
+	password string
+}
 
 // AuthenticateDocker phase implementation.
 type AuthenticateDocker struct {
 	phase.Analytics
 	phase.BasicPhase
+
+	logins map[string]loginConfig
 }
 
 // ShouldRun is true when registry credentials are set.
 func (p *AuthenticateDocker) ShouldRun() bool {
-	return os.Getenv("REGISTRY_USERNAME") != "" && os.Getenv("REGISTRY_PASSWORD") != ""
+	/**
+	* Possible scenarios:
+	*  NOTE: an empty imageRepo is the same as a "docker.io" value in comparisons
+	*  1. There is no MSR imageRepo
+	*    - if MKE specific, generic env vars exist, use them to login to the MKE imageRepo
+	*  2. [or] MKE and MSR both have the same imageRepo value
+	*    - if MKE specific, or MSR Specific or generic env vars exist, use them to login to the MKE imageRepo
+	*  3. [or] MKE and MSR both have imageRepos that are different, so two logins might be required
+	*    - if MKE specific, or generic env vars exist, use them to login to the MKE imageRepo
+	*    - [and] if MSR specific, or generic env vars exist, use them to login to the MSR imageRepo
+	 */
+
+	p.logins = map[string]loginConfig{} // registry keyed map
+
+	// validate the login info for the various scenarios, collecting sets of logins required on each host.
+	var discoverLoginErr error
+	if p.Config.Spec.MSR == nil { //nolint:gocritic
+		// check if there is an MKE specific, or a generic set of login information.
+		discoverLoginErr = addLogin(p.logins, p.Config.Spec.MKE.ImageRepo, []string{AuthEnvPrefixMke, AuthEnvPrefixGeneric})
+	} else if docker.CompareRepos(p.Config.Spec.MKE.ImageRepo, p.Config.Spec.MSR.ImageRepo) {
+		// check if there is either an MKE, MSR or generic set of login information.
+		discoverLoginErr = addLogin(p.logins, p.Config.Spec.MKE.ImageRepo, []string{AuthEnvPrefixMke, AuthEnvPrefixMsr, AuthEnvPrefixGeneric})
+	} else {
+		// check if there is a product or generic set of login information for each of the products.
+		discoverLoginErr = errors.Join(
+			addLogin(p.logins, p.Config.Spec.MKE.ImageRepo, []string{AuthEnvPrefixMke, AuthEnvPrefixGeneric}),
+			addLogin(p.logins, p.Config.Spec.MSR.ImageRepo, []string{AuthEnvPrefixMsr, AuthEnvPrefixGeneric}),
+		)
+	}
+	if discoverLoginErr != nil {
+		log.Errorf("error occurred discovering registry auth values: %s", discoverLoginErr.Error())
+	}
+
+	return len(p.logins) > 0
 }
 
 // Title for the phase.
@@ -26,16 +75,42 @@ func (p *AuthenticateDocker) Title() string {
 
 // Run authenticates docker on hosts.
 func (p *AuthenticateDocker) Run() error {
-	imageRepo := p.Config.Spec.MKE.ImageRepo
-
-	err := phase.RunParallelOnHosts(p.Config.Spec.Hosts, p.Config, func(h *api.Host, _ *api.ClusterConfig) error {
-		if err := h.AuthenticateDocker(imageRepo); err != nil {
-			return fmt.Errorf("%s: authenticate docker: %w", h, err)
+	// now run logins to each required registry on each of the hosts.
+	if err := phase.RunParallelOnHosts(p.Config.Spec.Hosts, p.Config, func(h *api.Host, _ *api.ClusterConfig) error {
+		errs := []error{}
+		for repo, lc := range p.logins { // running sequentially shouldn't be a problem for perfomance.
+			log.Infof("%s: authenticating docker for image repo %s", h, repo)
+			if err := h.Configurer.AuthenticateDocker(h, lc.username, lc.password, repo); err != nil {
+				errs = append(errs, fmt.Errorf("%s: host docker authentication failed: %w", h, err))
+			}
+		}
+		if len(errs) > 0 {
+			return errors.Join(errs...)
 		}
 		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("authentication failed: %w", err)
+	}); err != nil {
+		return fmt.Errorf("docker authentication failed on at least one host: %w", err)
 	}
+	return nil
+}
+
+// discover if there are any env based logins for the repo, based on a list of ENV variable prefixes, and build up the list of logins needed.
+func addLogin(logins map[string]loginConfig, repo string, prefixes []string) error {
+	user, pass, discoverErr := docker.DiscoverEnvLogin(prefixes)
+	if discoverErr != nil {
+		if errors.Is(discoverErr, docker.ErrNoEnvPasswordsFound) {
+			// if no envs were found for any of the prefixes, then we are not supposed to login for this repo
+			return nil
+		}
+		return discoverErr //nolint:wrapcheck
+	}
+
+	if strings.HasPrefix(repo, "docker.io/") { // docker.io is a special case for auth
+		// empty the value here so that we don't add docker.io more than once.
+		repo = ""
+	}
+
+	logins[repo] = loginConfig{username: user, password: pass} // we found one, so add it to the list.
+
 	return nil
 }

--- a/pkg/product/mke/phase/authenticate_docker.go
+++ b/pkg/product/mke/phase/authenticate_docker.go
@@ -78,7 +78,7 @@ func (p *AuthenticateDocker) Run() error {
 	// now run logins to each required registry on each of the hosts.
 	if err := phase.RunParallelOnHosts(p.Config.Spec.Hosts, p.Config, func(h *api.Host, _ *api.ClusterConfig) error {
 		errs := []error{}
-		for repo, lc := range p.logins { // running sequentially shouldn't be a problem for perfomance.
+		for repo, lc := range p.logins { // running sequentially shouldn't be a problem for performance.
 			log.Infof("%s: authenticating docker for image repo %s", h, repo)
 			if err := h.Configurer.AuthenticateDocker(h, lc.username, lc.password, repo); err != nil {
 				errs = append(errs, fmt.Errorf("%s: host docker authentication failed: %w", h, err))


### PR DESCRIPTION
- Env vars for authentication can now come from different variables
	- MKE vars can be MKE_REGISTER_USERNAME or REGISTER_USERNAME
	- MSR vars can be MSR_REGISTER_USERNAME or REGISTER_USERNAME
	- special handling if MSR and MKE have the same registry but different U/P set (akward)
- moved repo comparison to the docker module (w/ tests)
- moved registry auth detection from env variable to the docker module (w/ tests)

ALSO:
- small linting suggestion