### PR TITLE
PRODENG-2966 MCR upgrade skip detect refactor

### DIFF
--- a/examples/terraform/aws-simple/terraform.tfvars.template
+++ b/examples/terraform/aws-simple/terraform.tfvars.template
@@ -32,13 +32,13 @@ subnets = {
   "main" = {
     "cidr" = "172.31.0.0/17",
     "private" = false,
-    "nodegroups" = ["MngrUbuntu22",  "WrkUbuntu22", "MsrUbuntu22"]
+    "nodegroups" = ["MngrA",  "WrkA", "MsrA"]
   }
 }
 
 // one definition for each group of machines to include in the stack
 nodegroups = {
-  "MngrUbuntu22" = {
+  "MngrA" = {
     "platform" = "ubuntu_22.04",
     "count" = 1,
     "type" = "m6a.2xlarge",
@@ -46,7 +46,7 @@ nodegroups = {
     "role" = "manager",
     "user_data" = "sudo ufw allow 7946/tcp ; sudo ufw allow 10250/tcp "
   },
-  "WrkUbuntu22" = {
+  "WrkA" = {
     "platform" = "ubuntu_22.04",
     "count" = 1,
     "type" = "c6a.xlarge",
@@ -54,7 +54,7 @@ nodegroups = {
     "role" = "worker",
     "user_data" = "sudo ufw allow 7946/tcp ; sudo ufw allow 10250/tcp "
   }
-  "MsrUbuntu22" = {
+  "MsrA" = {
     "platform" = "ubuntu_22.04",
     "count" = 1,
     "type" = "c6a.xlarge",

--- a/pkg/product/mke/api/host.go
+++ b/pkg/product/mke/api/host.go
@@ -32,7 +32,7 @@ type HostMetadata struct {
 	MCRRestartRequired bool
 	ImagesToUpload     []string
 	TotalImageBytes    uint64
-	MCRInstalled       bool
+	MCRInstalled       bool // Indicates that in this run an MCR install has been executed (not that in installation has been discovered)
 }
 
 // MSRMetadata is metadata needed by MSR for configuration and is gathered at
@@ -347,7 +347,7 @@ func (h *Host) ConfigureMCR() error {
 
 	if h.Metadata.MCRVersion != "" {
 		h.Metadata.MCRRestartRequired = true
-		log.Debugf("%s: host marked for mcr restart", h)
+		log.Debugf("%s: host marked for mcr restart as MCR config was changed", h)
 	}
 
 	return nil

--- a/pkg/product/mke/phase/install_mcr.go
+++ b/pkg/product/mke/phase/install_mcr.go
@@ -70,11 +70,13 @@ func (p *InstallMCR) installMCR(h *api.Host) error {
 		return fmt.Errorf("%s: failed to authorize docker: %w", h, err)
 	}
 
-	// check MCR is running, maybe rebooting and updating metadata (don't bother restarting MCR, as we just installed/started it
-	if err := mcr.EnsureMCRVersion(h, p.Config.Spec.MCR.Version, false); err != nil {
+	// check MCR is running, maybe rebooting and updating metadata
+	if err := mcr.EnsureMCRVersion(h, p.Config.Spec.MCR.Version); err != nil {
 		return fmt.Errorf("failed while attempting to ensure the installed version %w", err)
 	}
 
+	log.Infof("%s: mcr installed", h)
 	h.Metadata.MCRInstalled = true
+	h.Metadata.MCRRestartRequired = false // we just installed, so a restart is not required
 	return nil
 }

--- a/pkg/product/mke/phase/uninstall_mcr.go
+++ b/pkg/product/mke/phase/uninstall_mcr.go
@@ -65,7 +65,7 @@ func (p *UninstallMCR) uninstallMCR(h *api.Host, config *api.ClusterConfig) erro
 	}
 
 	if err := h.Configurer.UninstallMCR(h, h.Metadata.MCRInstallScript, config.Spec.MCR); err != nil {
-		return fmt.Errorf("%s: uninstall container runtime: %w", h, err)
+		return fmt.Errorf("%s: uninstall container runtime failed: %w", h, err)
 	}
 
 	log.Infof("%s: mirantis container runtime uninstalled", h)


### PR DESCRIPTION
- mcr upgrade now:
	- skips if an install was just run
	- skips if the host config has the "skipUpgrade" flag
- mcr upgrade will prevent an mcr restart plan (even though it can't tell if MCR was actually upgraded) because restarts are disruptive.

ALSO:

- small go fmt change on the helm testutil