### PR TITLE
fix: quote docker login username

### DIFF
--- a/pkg/configurer/linux.go
+++ b/pkg/configurer/linux.go
@@ -202,7 +202,7 @@ func (c LinuxConfigurer) AuthorizeDocker(h os.Host) error {
 
 // AuthenticateDocker performs a docker login on the host.
 func (c LinuxConfigurer) AuthenticateDocker(h os.Host, user, pass, imageRepo string) error {
-	if err := h.Exec(c.DockerCommandf("login -u %s --password-stdin %s", user, imageRepo), exec.Stdin(pass), exec.RedactString(user, pass)); err != nil {
+	if err := h.Exec(c.DockerCommandf("login -u %s --password-stdin %s", escape.Quote(user), imageRepo), exec.Stdin(pass), exec.RedactString(user, pass)); err != nil {
 		return fmt.Errorf("failed to login to the docker registry: %w", err)
 	}
 	return nil


### PR DESCRIPTION
`docker login` as a part of `launchpad apply` fails when username contains special character [PRODENG-3039](https://mirantis.jira.com/browse/PRODENG-3039). 

- Quote docker login username so it can handle a username with special characters

[PRODENG-3039]: https://mirantis.jira.com/browse/PRODENG-3039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ