### PR TITLE
fix: allow wildcard channel version

### DIFF
--- a/pkg/product/common/api/mcr_config.go
+++ b/pkg/product/common/api/mcr_config.go
@@ -125,7 +125,9 @@ func processVersionChannelMatch(config *MCRConfig) error {
 		return fmt.Errorf("%w; channel parts could not be interpreted", ErrChannelDoesntMatchVersion)
 	}
 
-	if !strings.HasPrefix(chanParts[1], config.Version) {
+	// chanParts[1] is the major.minor version part of the channel like "25.0"
+	// config.Version is the full major.minor.patch version like "25.0.8"
+	if !strings.HasPrefix(config.Version, chanParts[1]) {
 		return fmt.Errorf("%w; MCR version does not match channel-version '%s' vs '%s'", ErrChannelDoesntMatchVersion, chanParts[1], config.Version)
 	}
 


### PR DESCRIPTION
<!--
NOTE: This is a comment. Comments will not be visible in the Markdown rendering. No need to delete these comments.

Try to stick with the imperative mood: https://initialcommit.com/blog/Git-Commit-Message-Imperative-Mood

Remember to submit using Conventional Commits when you create/submit your PR. Refs listed below:

- https://www.conventionalcommits.org/en/v1.0.0/
- https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index
- https://gist.github.com/Zekfad/f51cb06ac76e2457f11c80ed705c95a3
- https://simonberner.dev/posts/2021-02-03-conventional-commits-types
-->
## Description
<!--
Provide a description of this change below.
Bullet points (starting with `-`) or brief paragraphs preferred.
-->

- fix: allow wildcard channel version

We would like to install MCR 25.0.x with a wildcard channel like this in `launchpad.yaml`
``` yaml
  "mcr":
    "channel": "stable-25.0"
    "installURLLinux": "https://get.mirantis.com/"
    "installURLWindows": "https://get.mirantis.com/install.ps1"
    "repoURL": "https://repos.mirantis.com"
    "version": "25.0.8"
```

## Related Links
<!-- Include a bulleted list of links here, eg, JIRA, Confluence, GitHub commits or issues, etc. -->



## Testing
<!-- What tests did you run? Are you waiting for the CI to complete? -->

### 1. Before the change, it fails at `Validate Facts` phase.
```sh
▶ launchpad version
version: 1.5.13-tp2
commit: fd80698b975657d1a0729bedd07e6e8e7696d962

▶ launchpad apply --debug
.
.
.
INFO ==> Running phase: Validate Facts
DEBU [ssh] 18.224.153.30:22: executing `sudo -- getenforce | grep -iq enforcing 2> /dev/null`
DEBU [ssh] 18.224.153.30:22: sudo: getenforce: command not found
DEBU [ssh] 3.131.157.182:22: executing `sudo -- getenforce | grep -iq enforcing 2> /dev/null`
DEBU [ssh] 3.131.157.182:22: sudo: getenforce: command not found
DEBU [ssh] 3.21.232.53:22: executing `sudo -- getenforce | grep -iq enforcing 2> /dev/null`
DEBU [ssh] 3.21.232.53:22: sudo: getenforce: command not found
DEBU phase 'Validate Facts' took 0s
DEBU tracking analytics event 'Validate Facts'
DEBU tracking analytics event 'Gather Facts'
DEBU tracking analytics event 'Detect host operating systems'
DEBU tracking analytics event 'Check For Upgrades'
DEBU tracking analytics event 'Cluster Apply Failed'
INFO See /Users/eiichi.kitagawa/.mirantis-launchpad/cluster/25YAJ9/apply.log for more logs
FATA failed to apply cluster: failed to apply MKE: phase failure: Validate Facts => validation failed
MCR version and channel don't match, which is required for versions >= 25.0.0; MCR version does not match channel-version '25.0' vs '25.0.8'
```

### 2. Test run with the proposed fix.

Validation works out and Launchpad moves onto next phase.

``` sh
▶ launchpad version
version: 1.5.13-tp2-SNAPSHOT-cbc6a37
commit: cbc6a37eb01b98b172b86e0f929ac7ac07ea8160

▶ launchpad apply --debug
.
.
.
INFO ==> Running phase: Validate Facts
DEBU [ssh] 18.224.153.30:22: executing `sudo -- getenforce | grep -iq enforcing 2> /dev/null`
DEBU [ssh] 18.224.153.30:22: sudo: getenforce: command not found
DEBU [ssh] 3.131.157.182:22: executing `sudo -- getenforce | grep -iq enforcing 2> /dev/null`
DEBU [ssh] 3.131.157.182:22: sudo: getenforce: command not found
DEBU [ssh] 3.21.232.53:22: executing `sudo -- getenforce | grep -iq enforcing 2> /dev/null`
DEBU [ssh] 3.21.232.53:22: sudo: getenforce: command not found
DEBU did not find a MSR installation, falling back to the first MSR host
DEBU validating data plane settings
DEBU phase 'Validate Facts' took 0s
DEBU phase 'Validate Facts' completed successfully
DEBU preparing phase 'Validate Hosts'
```

### 3. This change breaks the unit test
``` sh
▶ go test -v pkg/product/common/api/mcr_config_validate_test.go
=== RUN   Test_ValidateNil
--- PASS: Test_ValidateNil (0.00s)
=== RUN   Test_ValidateNilFIPS
--- PASS: Test_ValidateNilFIPS (0.00s)
=== RUN   Test_ValidateEmptyVersion
--- PASS: Test_ValidateEmptyVersion (0.00s)
=== RUN   Test_ValidateInvalidVersion
--- PASS: Test_ValidateInvalidVersion (0.00s)
=== RUN   Test_ValidateMissingChannelVersion
--- PASS: Test_ValidateMissingChannelVersion (0.00s)
=== RUN   Test_ValidateWrongChannelVersion
--- PASS: Test_ValidateWrongChannelVersion (0.00s)
=== RUN   Test_ValidateWrongChannelVersionFIPS
--- PASS: Test_ValidateWrongChannelVersionFIPS (0.00s)
=== RUN   Test_ValidateIncompleteChannelVersion
    mcr_config_validate_test.go:104:
        	Error Trace:	/Users/eiichi.kitagawa/repos/launchpad/pkg/product/common/api/mcr_config_validate_test.go:104
        	Error:      	Target error should be in err chain:
        	            	expected: "MCR version and channel don't match, which is required for versions >= 25.0.0"
        	            	in chain:
        	Test:       	Test_ValidateIncompleteChannelVersion
        	Messages:   	did not receive expected error from invalid MCR config which is missing an incomplete channel version
--- FAIL: Test_ValidateIncompleteChannelVersion (0.00s)
=== RUN   Test_ValidateIncompleteChannelVersionFIPS
    mcr_config_validate_test.go:128:
        	Error Trace:	/Users/eiichi.kitagawa/repos/launchpad/pkg/product/common/api/mcr_config_validate_test.go:128
        	Error:      	Target error should be in err chain:
        	            	expected: "MCR version and channel don't match, which is required for versions >= 25.0.0"
        	            	in chain:
        	Test:       	Test_ValidateIncompleteChannelVersionFIPS
        	Messages:   	did not receive expected error from invalid MCR config which is missing an incomplete channel version
--- FAIL: Test_ValidateIncompleteChannelVersionFIPS (0.00s)
=== RUN   Test_ValidateWildcardChannelVersion
    mcr_config_validate_test.go:137:
        	Error Trace:	/Users/eiichi.kitagawa/repos/launchpad/pkg/product/common/api/mcr_config_validate_test.go:137
        	Error:      	Expected nil, but got: &fmt.wrapError{msg:"MCR version and channel don't match, which is required for versions >= 25.0.0; MCR version does not match channel-version '25.0.9' vs '25.0'", err:(*errors.errorString)(0x104a7a410)}
        	Test:       	Test_ValidateWildcardChannelVersion
        	Messages:   	received unexpected error for valid MCR config which uses a wildcard version and specific channel
--- FAIL: Test_ValidateWildcardChannelVersion (0.00s)
=== RUN   Test_ValidateWildcardChannelVersionFIPS
    mcr_config_validate_test.go:146:
        	Error Trace:	/Users/eiichi.kitagawa/repos/launchpad/pkg/product/common/api/mcr_config_validate_test.go:146
        	Error:      	Expected nil, but got: &fmt.wrapError{msg:"MCR version and channel don't match, which is required for versions >= 25.0.0; MCR version does not match channel-version '25.0.9' vs '25.0'", err:(*errors.errorString)(0x104a7a410)}
        	Test:       	Test_ValidateWildcardChannelVersionFIPS
        	Messages:   	received unexpected error for valid MCR config which uses a wildcard version and specific channel w/ FIPS
--- FAIL: Test_ValidateWildcardChannelVersionFIPS (0.00s)
FAIL
FAIL	command-line-arguments	0.429s
FAIL
```

<!-- A reminder to click the Preview tab above to verify before submitting. -->
