### PR TITLE
fix: config version vs channel check for MCR installation

### DIFF
--- a/pkg/product/common/api/mcr_config.go
+++ b/pkg/product/common/api/mcr_config.go
@@ -116,17 +116,14 @@ func processVersionChannelMatch(config *MCRConfig) error {
 	}
 
 	channel := strings.TrimSuffix(config.Channel, fipsChannelSuffix)
-	chanParts := strings.Split(channel, "-")
-	if len(chanParts) == 1 {
-		return fmt.Errorf("%w; channel has no version (%s)", ErrChannelDoesntMatchVersion, config.Channel)
-	}
-
-	if len(chanParts) > 2 {
-		return fmt.Errorf("%w; channel parts could not be interpreted", ErrChannelDoesntMatchVersion)
+	chanParts := strings.SplitN(channel, "-", 2)
+	if len(chanParts) != 2 {
+        return fmt.Errorf("%w; channel parts could not be interpreted (%s)", ErrChannelDoesntMatchVersion, config.Channel)
 	}
 
 	if !strings.HasPrefix(chanParts[1], config.Version) {
-		return fmt.Errorf("%w; MCR version does not match channel-version '%s' vs '%s'", ErrChannelDoesntMatchVersion, chanParts[1], config.Version)
+		return fmt.Errorf("%w; MCR version mismatch: '%s' vs '%s'",
+			ErrChannelDoesntMatchVersion, chanParts[1], config.Version)
 	}
 
 	return nil


### PR DESCRIPTION
<!--
NOTE: This is a comment. Comments will not be visible in the Markdown rendering. No need to delete these comments.

Try to stick with the imperative mood: https://initialcommit.com/blog/Git-Commit-Message-Imperative-Mood

Remember to submit using Conventional Commits when you create/submit your PR. Refs listed below:

- https://www.conventionalcommits.org/en/v1.0.0/
- https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index
- https://gist.github.com/Zekfad/f51cb06ac76e2457f11c80ed705c95a3
- https://simonberner.dev/posts/2021-02-03-conventional-commits-types
-->
## Description
<!--
Provide a description of this change below.
Bullet points (starting with `-`) or brief paragraphs preferred.
-->

- fix: config version vs channel check for MCR installation

## Why make this change

Installation of an internal MCR build fails when I set it like this.

``` yaml
  "mcr":
    "channel": "test-25.0.12/fips"
    "installURLLinux": "https://get.mirantis.com/"
    "installURLWindows": "https://get.mirantis.com/install.ps1"
    "repoURL": "https://repos-internal.mirantis.com"
    "version": "25.0.12-tp1"
```

I get this output
``` sh
▶ launchpad version
version: 1.5.13-tp2
commit: fd80698b975657d1a0729bedd07e6e8e7696d962

▶ launchpad apply
.
.
.
INFO ==> Running phase: Validate Facts
INFO See /Users/eiichi.kitagawa/.mirantis-launchpad/cluster/4O7MR4/apply.log for more logs
FATA failed to apply cluster: failed to apply MKE: phase failure: Validate Facts => validation failed
MCR version and channel don't match, which is required for versions >= 25.0.0; MCR version does not match channel-version '25.0.12' vs '25.0.12-tp1'
```

## Related Links
<!-- Include a bulleted list of links here, eg, JIRA, Confluence, GitHub commits or issues, etc. -->


PRODENG-3068


## Testing
<!-- What tests did you run? Are you waiting for the CI to complete? -->

### Test run with the proposed fix.

Component tests
``` sh
▶ go test -v pkg/product/common/api/mcr_config_validate_test.go
=== RUN   Test_ValidateNil
--- PASS: Test_ValidateNil (0.00s)
=== RUN   Test_ValidateNilFIPS
--- PASS: Test_ValidateNilFIPS (0.00s)
=== RUN   Test_ValidateEmptyVersion
--- PASS: Test_ValidateEmptyVersion (0.00s)
=== RUN   Test_ValidateInvalidVersion
--- PASS: Test_ValidateInvalidVersion (0.00s)
=== RUN   Test_ValidateMissingChannelVersion
--- PASS: Test_ValidateMissingChannelVersion (0.00s)
=== RUN   Test_ValidateWrongChannelVersion
--- PASS: Test_ValidateWrongChannelVersion (0.00s)
=== RUN   Test_ValidateWrongChannelVersionFIPS
--- PASS: Test_ValidateWrongChannelVersionFIPS (0.00s)
=== RUN   Test_ValidateIncompleteChannelVersion
--- PASS: Test_ValidateIncompleteChannelVersion (0.00s)
=== RUN   Test_ValidateIncompleteChannelVersionFIPS
--- PASS: Test_ValidateIncompleteChannelVersionFIPS (0.00s)
=== RUN   Test_ValidateWildcardChannelVersion
--- PASS: Test_ValidateWildcardChannelVersion (0.00s)
=== RUN   Test_ValidateWildcardChannelVersionFIPS
--- PASS: Test_ValidateWildcardChannelVersionFIPS (0.00s)
PASS
ok  	command-line-arguments	0.267s
```


<!-- A reminder to click the Preview tab above to verify before submitting. -->
