### PR TITLE
PRODENG-3132 MKE image regex and registry ports

### DIFF
--- a/pkg/docker/image.go
+++ b/pkg/docker/image.go
@@ -13,7 +13,7 @@ import (
 )
 
 // regex for pulling images names from command string output, common for msr/mke bootstrappers.
-var imageListFromOutputString = regexp.MustCompile(`(?m)^(?P<repo>[\w\.\/_-]*)\/(?P<name>[\w\.\/_-]+?):(?P<tag>[\w\.\/_-]+?)$`)
+var imageListFromOutputString = regexp.MustCompile(`(?m)^(?<repo>[\w\.-]*)(?<port>:[0-9]*)?(?<path>[\w-\/]*)?\/(?<name>[\w-]+)\:(?<tag>[\w\.-]+)[" "\t]*$`)
 
 // Image describes a docker image.
 type Image struct {
@@ -34,9 +34,9 @@ func NewImage(s string) *Image {
 func AllFromString(s string) (list []*Image) {
 	for _, match := range imageListFromOutputString.FindAllStringSubmatch(s, -1) {
 		list = append(list, &Image{
-			Repository: match[1],
-			Name:       match[2],
-			Tag:        match[3],
+			Repository: strings.Join([]string{match[1], match[2], match[3]}, ""),
+			Name:       match[4],
+			Tag:        match[5],
 		})
 	}
 	return list

--- a/pkg/docker/image_test.go
+++ b/pkg/docker/image_test.go
@@ -1,19 +1,20 @@
-package docker
+package docker_test
 
 import (
 	"testing"
 
+	"github.com/Mirantis/launchpad/pkg/docker"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewImage(t *testing.T) {
-	image := NewImage("xyz/foofoo:1.2.3-latest")
+	image := docker.NewImage("xyz/foofoo:1.2.3-latest")
 	require.Equal(t, "xyz", image.Repository)
 	require.Equal(t, "foofoo", image.Name)
 	require.Equal(t, "1.2.3-latest", image.Tag)
 	require.Equal(t, "xyz/foofoo:1.2.3-latest", image.String())
 
-	image = NewImage("docker.io/xyz/foofoo:1.2.3-latest")
+	image = docker.NewImage("docker.io/xyz/foofoo:1.2.3-latest")
 	require.Equal(t, "docker.io/xyz", image.Repository)
 	require.Equal(t, "foofoo", image.Name)
 	require.Equal(t, "1.2.3-latest", image.Tag)
@@ -21,7 +22,7 @@ func TestNewImage(t *testing.T) {
 }
 
 func TestAllFromString(t *testing.T) {
-	images := AllFromString(`docker.io/foo/bar:1.2.3
+	images := docker.AllFromString(`docker.io/foo/bar:1.2.3
 docker.io/foo/bar2:1.2.3`)
 	require.Equal(t, 2, len(images))
 	require.Equal(t, "docker.io/foo", images[0].Repository)
@@ -30,12 +31,22 @@ docker.io/foo/bar2:1.2.3`)
 }
 
 func TestAllToRepository(t *testing.T) {
-	images := AllFromString(`docker.io/foo/bar:1.2.3
-docker.io/foo/bar2:1.2.3`)
-	moved := AllToRepository(images, "custom.example.com/repo")
-	require.Equal(t, 2, len(moved))
+	images := docker.AllFromString(`docker.io/foo/bar:1.2.3
+docker.io/foo/bar2:1.2.3-tp1  
+docker.io:8888/foo2/bar3:PRODENG
+
+`) // there is whitespace EOL on purpose
+
+	require.Equal(t, 3, len(images))
+	require.Equal(t, "docker.io/foo/bar:1.2.3", images[0].String())
+	require.Equal(t, "docker.io/foo/bar2:1.2.3-tp1", images[1].String())
+	require.Equal(t, "docker.io:8888/foo2/bar3:PRODENG", images[2].String())
+
+	moved := docker.AllToRepository(images, "custom.example.com/repo")
+	require.Equal(t, 3, len(moved))
 	require.Equal(t, "custom.example.com/repo/bar:1.2.3", moved[0].String())
-	require.Equal(t, "custom.example.com/repo/bar2:1.2.3", moved[1].String())
+	require.Equal(t, "custom.example.com/repo/bar2:1.2.3-tp1", moved[1].String())
+	require.Equal(t, "custom.example.com/repo/bar3:PRODENG", moved[2].String())
 }
 
 // MKE3.8.7 forced us to refine the regex used. This test uses some real MKE output w/ --debug to confirm
@@ -52,7 +63,7 @@ time="2025-07-03T01:00:12Z" level=info msg="Bootsrapper image version: 3.8.7"
 msr.ci.mirantis.com/mirantiseng/ucp-agent:3.8.7
 msr.ci.mirantis.com/mirantiseng/ucp-alertmanager:3.8.7
 msr.ci.mirantis.com/mirantiseng/ucp-auth-store:3.8.7`
-	images := AllFromString(mke387output)
+	images := docker.AllFromString(mke387output)
 	require.Equal(t, 3, len(images))
 	require.Equal(t, "msr.ci.mirantis.com/mirantiseng/ucp-agent:3.8.7", images[0].String())
 	require.Equal(t, "msr.ci.mirantis.com/mirantiseng/ucp-alertmanager:3.8.7", images[1].String())


### PR DESCRIPTION
- fix MKE image listing for registries with ports in the URI

ALSO

- make the docker image unit tests external to the docker package (golang standard)