### PR TITLE
PRODENG-3148 mcr version detect cleanup

### DIFF
--- a/pkg/product/common/api/mcr_config.go
+++ b/pkg/product/common/api/mcr_config.go
@@ -109,7 +109,7 @@ func (c *MCRConfig) Validate() error {
 //
 //	If the channel doesn't contain the right version component then version pinning won't work
 func processVersionChannelMatch(config *MCRConfig) error {
-	ver, vererr := processVersionIsAVersion(config)
+	ver, vererr := version.NewSemver(config.Version)
 	if vererr != nil {
 		return fmt.Errorf("%w; %w", ErrInvalidVersion, vererr)
 	}
@@ -134,23 +134,4 @@ func processVersionChannelMatch(config *MCRConfig) error {
 	}
 
 	return nil
-}
-
-// go-version.NewVersion throws a runtime error if you pass it something invalid
-// so we use, this to provide a runtime safe process for the version parsing.
-func processVersionIsAVersion(config *MCRConfig) (ver *version.Version, err error) {
-	if config.Version == "" {
-		err = ErrInvalidVersion
-		return ver, err
-	}
-
-	defer func() {
-		// recover from panic if one occurred. Set err to nil otherwise.
-		if recover() != nil {
-			err = ErrInvalidVersion
-		}
-	}()
-
-	ver, err = version.NewVersion(config.Version)
-	return ver, err //nolint:wrapcheck
 }


### PR DESCRIPTION
- go-version no longer throws a runtime error on invalid versions, so we can drop our custom error catch version detection function

NOTE

What is this: we had issues when we first started analyzing the mcr version in
    the configuration, as some invalid values would produce a runtime error. The
    error came right out of hashicorps go-version library, so our only option
    was to wrap the function and catch any runtime errors.
    We also included a unit test which validated that a proper error was returned
    on the invalid version value, to confirm in unit testing that the runtime
    error was caught

Why isn't it needed anymore: I ran the go-version function recently without the
    wrapper and found that the runtime exception no longer occurs, meaning that
    our wrapper is no longer needed.  The unit test now runs without exception
    without the wrapper.
    Additionally, the go-version code now properly handles CalVer values,
    which may have leading zeroes in values.