### PR TITLE
PRODENG-3392 Run Go lint on arc-runner-set-mirantis-public

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-set-mirantis-public
     if: github.ref != 'refs/heads/main'
     steps:
       - name: Check out code into the Go module directory


### PR DESCRIPTION
 - Migrating to selfhosted GHA runners