### PR TITLE
fix: inject version and commit via ldflags in CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
               output_name+=".exe"
             fi
             echo "Building $output_name"
-            GOOS=$GOOS GOARCH=$GOARCH go build -o "$output_name" ./main.go
+            GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-X github.com/Mirantis/launchpad/version.GitCommit=$GITHUB_SHA" -o "$output_name" ./main.go
           done
 
       - name: Upload artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
               output_name+=".exe"
             fi
             echo "Building $output_name"
-            GOOS=$GOOS GOARCH=$GOARCH go build -o "$output_name" ./main.go
+            GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-X github.com/Mirantis/launchpad/version.Version=${VERSION#v} -X github.com/Mirantis/launchpad/version.GitCommit=$GITHUB_SHA" -o "$output_name" ./main.go
           done
       - name: Generate checksums
         run: |


### PR DESCRIPTION
The release and build workflows called go build without -ldflags, so the binary always had Version=0.0.0 and GitCommit=HEAD.

- release.yml: inject both Version (from tag) and GitCommit
- build.yml: inject GitCommit (no version tag on main builds)