### PR TITLE
ENGINE-1383: Handle Windows exit code 3010 and fix reboot after MCR install

### DIFF
--- a/pkg/configurer/common.go
+++ b/pkg/configurer/common.go
@@ -10,6 +10,10 @@ import (
 	"github.com/k0sproject/rig/os"
 )
 
+type rebootable interface {
+	Reboot() error
+}
+
 type DockerConfigurer struct{}
 
 // GetDockerInfo gets docker info from the host.

--- a/pkg/configurer/installer.go
+++ b/pkg/configurer/installer.go
@@ -24,10 +24,6 @@ func GetInstaller(source string) (string, error) {
 		return path, nil
 	}
 
-	if path == "" {
-		return "", fmt.Errorf("%w; skipping failed installer download", ErrInstallerDownloadFailed)
-	}
-
 	path, getErr := downloadInstaller(source)
 	if getErr != nil {
 		return "", fmt.Errorf("%w, installer download failed; %s", ErrInstallerDownloadFailed, getErr.Error())

--- a/pkg/configurer/windows.go
+++ b/pkg/configurer/windows.go
@@ -137,7 +137,7 @@ func isExitCode3010(err error) bool {
 //
 // TODO: move this fix upstream into the k0sproject/rig Windows configurer.
 func (c WindowsConfigurer) Reboot(h os.Host) error {
-	if err := h.Exec("shutdown /r /t 0"); err != nil {
+	if err := h.Exec("shutdown /r /f /t 0"); err != nil {
 		// The OS may kill the WinRM session before the command returns;
 		// treat connection-level errors as success since the reboot is underway.
 		errMsg := err.Error()

--- a/pkg/configurer/windows.go
+++ b/pkg/configurer/windows.go
@@ -119,30 +119,32 @@ func isExitCode3010(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "3010")
 }
 
-// Reboot issues an immediate forced restart via shutdown /r /t 0, which
-// reliably reboots Windows hosts even when a reboot is already pending (e.g.
-// after an MCR install that exits with code 3010). The rig implementation uses
-// 'shutdown /r /t 5' which can be silently ignored in that state.
+// Reboot triggers an immediate forced restart by scheduling a one-shot SYSTEM
+// task that runs 'shutdown /r /f /t 0'. Running via a scheduled task bypasses
+// the filtered Administrator token used by WinRM sessions, which lacks
+// SeShutdownPrivilege on AWS EC2 instances. The rig implementation uses
+// 'shutdown /r /t 5' directly in the WinRM session, which is silently ignored
+// in that context.
 //
-// After issuing the command we sleep briefly so that Windows has time to begin
+// After scheduling the task we sleep briefly so that Windows has time to begin
 // its shutdown sequence before the caller's waitForHost poll loop starts.
-// Without this delay the host may return WinRM responses for several seconds
-// after shutdown /r /t 0 returns, causing waitForHost to never see an offline
-// window.
-//
-// The WinRM session may be forcibly terminated by the OS during shutdown,
-// causing the exec to return an error. We tolerate that by also accepting
-// errors whose message contains "connection" or "closed" — those indicate
-// the reboot is in progress.
 //
 // TODO: move this fix upstream into the k0sproject/rig Windows configurer.
 func (c WindowsConfigurer) Reboot(h os.Host) error {
-	if err := h.Exec("shutdown /r /f /t 0"); err != nil {
-		// The OS may kill the WinRM session before the command returns;
-		// treat connection-level errors as success since the reboot is underway.
+	const taskName = "LaunchpadReboot"
+	// Create (or overwrite) a one-shot scheduled task running as SYSTEM, then
+	// trigger it immediately. SYSTEM always holds SeShutdownPrivilege.
+	create := fmt.Sprintf(`schtasks /create /tn "%s" /tr "shutdown /r /f /t 0" /sc once /st 00:00 /f /ru SYSTEM`, taskName)
+	if err := h.Exec(create); err != nil {
+		return fmt.Errorf("failed to create reboot task: %w", err)
+	}
+	run := fmt.Sprintf(`schtasks /run /tn "%s"`, taskName)
+	if err := h.Exec(run); err != nil {
+		// Tolerate connection-level errors; the OS may kill WinRM as it starts
+		// rebooting before the run command returns.
 		errMsg := err.Error()
 		if !strings.Contains(errMsg, "connection") && !strings.Contains(errMsg, "closed") && !strings.Contains(errMsg, "EOF") {
-			return fmt.Errorf("failed to reboot: %w", err)
+			return fmt.Errorf("failed to run reboot task: %w", err)
 		}
 	}
 	// Allow Windows time to start shutting down before waitForHost begins polling.

--- a/pkg/configurer/windows.go
+++ b/pkg/configurer/windows.go
@@ -119,6 +119,19 @@ func isExitCode3010(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "3010")
 }
 
+// Reboot issues a forced restart via PowerShell's Restart-Computer, which
+// reliably reboots Windows hosts even when a reboot is already pending (e.g.
+// after an MCR install that exits with code 3010). The rig implementation uses
+// 'shutdown /r /t 5' which can be silently ignored in that state.
+//
+// TODO: move this fix upstream into the k0sproject/rig Windows configurer.
+func (c WindowsConfigurer) Reboot(h os.Host) error {
+	if err := h.Exec(`powershell -Command "Restart-Computer -Force"`); err != nil {
+		return fmt.Errorf("failed to reboot: %w", err)
+	}
+	return nil
+}
+
 // UninstallMCR uninstalls docker-ee engine
 // This relies on using the http://get.mirantis.com/install.ps1 script with the '-Uninstall' option, and some cleanup as per
 // https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-docker/configure-docker-daemon#how-to-uninstall-docker

--- a/pkg/configurer/windows.go
+++ b/pkg/configurer/windows.go
@@ -39,10 +39,6 @@ func (c WindowsConfigurer) MCRConfigPath() string {
 	return `C:\ProgramData\Docker\config\daemon.json`
 }
 
-type rebootable interface {
-	Reboot() error
-}
-
 var errRebootRequired = fmt.Errorf("reboot required")
 
 // InstallMCRLicense for license install..
@@ -88,21 +84,39 @@ func (c WindowsConfigurer) InstallMCR(h os.Host, engineConfig commonconfig.MCRCo
 	log.Infof("%s: running installer", h)
 
 	output, err := h.ExecOutput(installCommand)
+
+	needsReboot := false
 	if err != nil {
-		return fmt.Errorf("failed to run MCR installer: %w", err)
+		if isExitCode3010(err) {
+			needsReboot = true
+		} else {
+			return fmt.Errorf("failed to run MCR installer: %w", err)
+		}
 	}
 
-	if strings.Contains(output, "Your machine needs to be rebooted") {
-		log.Warnf("%s: host needs to be rebooted", h)
-		if rh, ok := h.(rebootable); ok {
-			if err := rh.Reboot(); err != nil {
-				return fmt.Errorf("%s: failed to reboot host: %w", h, err)
-			}
+	if !needsReboot && strings.Contains(output, "Your machine needs to be rebooted") {
+		needsReboot = true
+	}
+
+	if needsReboot {
+		log.Warnf("%s: host needs to be rebooted after MCR install", h)
+		rh, ok := h.(rebootable)
+		if !ok {
+			return fmt.Errorf("%s: %w: host does not support reboot", h, errRebootRequired)
 		}
-		return fmt.Errorf("%s: %w: host isn't rebootable", h, errRebootRequired)
+		if err := rh.Reboot(); err != nil {
+			return fmt.Errorf("%s: failed to reboot host: %w", h, err)
+		}
+		return nil
 	}
 
 	return nil
+}
+
+// isExitCode3010 checks if the error is a command failure with Windows exit
+// code 3010 (ERROR_SUCCESS_REBOOT_REQUIRED).
+func isExitCode3010(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "3010")
 }
 
 // UninstallMCR uninstalls docker-ee engine

--- a/pkg/configurer/windows.go
+++ b/pkg/configurer/windows.go
@@ -119,16 +119,34 @@ func isExitCode3010(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "3010")
 }
 
-// Reboot issues a forced restart via PowerShell's Restart-Computer, which
+// Reboot issues an immediate forced restart via shutdown /r /t 0, which
 // reliably reboots Windows hosts even when a reboot is already pending (e.g.
 // after an MCR install that exits with code 3010). The rig implementation uses
 // 'shutdown /r /t 5' which can be silently ignored in that state.
 //
+// After issuing the command we sleep briefly so that Windows has time to begin
+// its shutdown sequence before the caller's waitForHost poll loop starts.
+// Without this delay the host may return WinRM responses for several seconds
+// after shutdown /r /t 0 returns, causing waitForHost to never see an offline
+// window.
+//
+// The WinRM session may be forcibly terminated by the OS during shutdown,
+// causing the exec to return an error. We tolerate that by also accepting
+// errors whose message contains "connection" or "closed" — those indicate
+// the reboot is in progress.
+//
 // TODO: move this fix upstream into the k0sproject/rig Windows configurer.
 func (c WindowsConfigurer) Reboot(h os.Host) error {
-	if err := h.Exec(`powershell -Command "Restart-Computer -Force"`); err != nil {
-		return fmt.Errorf("failed to reboot: %w", err)
+	if err := h.Exec("shutdown /r /t 0"); err != nil {
+		// The OS may kill the WinRM session before the command returns;
+		// treat connection-level errors as success since the reboot is underway.
+		errMsg := err.Error()
+		if !strings.Contains(errMsg, "connection") && !strings.Contains(errMsg, "closed") && !strings.Contains(errMsg, "EOF") {
+			return fmt.Errorf("failed to reboot: %w", err)
+		}
 	}
+	// Allow Windows time to start shutting down before waitForHost begins polling.
+	time.Sleep(15 * time.Second)
 	return nil
 }
 

--- a/pkg/configurer/windows.go
+++ b/pkg/configurer/windows.go
@@ -119,22 +119,26 @@ func isExitCode3010(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "3010")
 }
 
-// Reboot triggers an immediate forced restart by scheduling a one-shot SYSTEM
-// task that runs 'shutdown /r /f /t 0'. Running via a scheduled task bypasses
-// the filtered Administrator token used by WinRM sessions, which lacks
-// SeShutdownPrivilege on AWS EC2 instances. The rig implementation uses
-// 'shutdown /r /t 5' directly in the WinRM session, which is silently ignored
-// in that context.
+// Reboot triggers an immediate forced restart by scheduling a SYSTEM-context
+// task that runs 'shutdown /r /f /t 0', then immediately triggering it.
+// Running via a scheduled task bypasses the filtered Administrator token used
+// by WinRM sessions on AWS EC2, which lacks SeShutdownPrivilege. The rig
+// implementation uses 'shutdown /r /t 5' directly in the WinRM session,
+// which is silently ignored in that context.
 //
-// After scheduling the task we sleep briefly so that Windows has time to begin
-// its shutdown sequence before the caller's waitForHost poll loop starts.
+// /sc onstart is used instead of /sc once to avoid schtasks writing a
+// stderr warning about the start time being in the past, which rig treats
+// as an error.
+//
+// After scheduling the task we sleep briefly so that Windows has time to
+// begin its shutdown sequence before the caller's waitForHost poll loop starts.
 //
 // TODO: move this fix upstream into the k0sproject/rig Windows configurer.
 func (c WindowsConfigurer) Reboot(h os.Host) error {
 	const taskName = "LaunchpadReboot"
 	// Create (or overwrite) a one-shot scheduled task running as SYSTEM, then
 	// trigger it immediately. SYSTEM always holds SeShutdownPrivilege.
-	create := fmt.Sprintf(`schtasks /create /tn "%s" /tr "shutdown /r /f /t 0" /sc once /st 00:00 /f /ru SYSTEM`, taskName)
+	create := fmt.Sprintf(`schtasks /create /tn "%s" /tr "shutdown /r /f /t 0" /sc onstart /f /ru SYSTEM`, taskName)
 	if err := h.Exec(create); err != nil {
 		return fmt.Errorf("failed to create reboot task: %w", err)
 	}

--- a/pkg/configurer/windows.go
+++ b/pkg/configurer/windows.go
@@ -107,6 +107,11 @@ func (c WindowsConfigurer) InstallMCR(h os.Host, engineConfig commonconfig.MCRCo
 		if err := rh.Reboot(); err != nil {
 			return fmt.Errorf("%s: failed to reboot host: %w", h, err)
 		}
+		// Machine is back up. Delete the ONSTART scheduled task so it does not
+		// trigger another reboot on subsequent startups.
+		if err := h.Exec(`schtasks /delete /tn "LaunchpadReboot" /f`); err != nil {
+			log.Warnf("%s: failed to clean up LaunchpadReboot task: %s", h, err)
+		}
 		return nil
 	}
 

--- a/pkg/configurer/windows.go
+++ b/pkg/configurer/windows.go
@@ -141,9 +141,11 @@ func isExitCode3010(err error) bool {
 // TODO: move this fix upstream into the k0sproject/rig Windows configurer.
 func (c WindowsConfigurer) Reboot(h os.Host) error {
 	const taskName = "LaunchpadReboot"
-	// Create (or overwrite) a one-shot scheduled task running as SYSTEM, then
-	// trigger it immediately. SYSTEM always holds SeShutdownPrivilege.
-	create := fmt.Sprintf(`schtasks /create /tn "%s" /tr "shutdown /r /f /t 0" /sc onstart /f /ru SYSTEM`, taskName)
+	// Create a SYSTEM-context ONSTART task that runs 'shutdown /r /f /t 5'.
+	// The 5-second delay gives us time to delete the task before the OS
+	// actually executes the reboot, preventing it from firing again on the
+	// next startup.
+	create := fmt.Sprintf(`schtasks /create /tn "%s" /tr "shutdown /r /f /t 5" /sc onstart /f /ru SYSTEM`, taskName)
 	if err := h.Exec(create); err != nil {
 		return fmt.Errorf("failed to create reboot task: %w", err)
 	}
@@ -156,7 +158,15 @@ func (c WindowsConfigurer) Reboot(h os.Host) error {
 			return fmt.Errorf("failed to run reboot task: %w", err)
 		}
 	}
-	// Allow Windows time to start shutting down before waitForHost begins polling.
+	// Delete the task immediately while the 5-second shutdown timer is still
+	// counting down. This prevents it from re-firing on subsequent startups.
+	del := fmt.Sprintf(`schtasks /delete /tn "%s" /f`, taskName)
+	if err := h.Exec(del); err != nil {
+		// Best-effort: warn but don't fail — the post-reboot cleanup in
+		// InstallMCR will attempt deletion again once the host is back up.
+		log.Warnf("%v: failed to pre-delete reboot task (will retry after reboot): %s", h, err)
+	}
+	// Allow Windows time to complete shutdown before waitForHost begins polling.
 	time.Sleep(15 * time.Second)
 	return nil
 }

--- a/pkg/configurer/windows.go
+++ b/pkg/configurer/windows.go
@@ -121,22 +121,24 @@ func (c WindowsConfigurer) InstallMCR(h os.Host, engineConfig commonconfig.MCRCo
 // isExitCode3010 checks if the error is a command failure with Windows exit
 // code 3010 (ERROR_SUCCESS_REBOOT_REQUIRED).
 func isExitCode3010(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "3010")
+	return err != nil && strings.Contains(err.Error(), "non-zero exit code: 3010")
 }
 
 // Reboot triggers an immediate forced restart by scheduling a SYSTEM-context
-// task that runs 'shutdown /r /f /t 0', then immediately triggering it.
+// one-shot task that runs 'shutdown /r /f /t 5', then immediately triggering
+// and deleting it within the 5-second countdown window.
+//
 // Running via a scheduled task bypasses the filtered Administrator token used
-// by WinRM sessions on AWS EC2, which lacks SeShutdownPrivilege. The rig
-// implementation uses 'shutdown /r /t 5' directly in the WinRM session,
-// which is silently ignored in that context.
+// by WinRM sessions on AWS EC2, which lacks SeShutdownPrivilege. Issuing
+// 'shutdown /r' directly in the WinRM session is silently ignored in that
+// context.
 //
 // /sc onstart is used instead of /sc once to avoid schtasks writing a
 // stderr warning about the start time being in the past, which rig treats
-// as an error.
-//
-// After scheduling the task we sleep briefly so that Windows has time to
-// begin its shutdown sequence before the caller's waitForHost poll loop starts.
+// as an error. The task is deleted immediately after triggering (while the
+// 5-second timer counts down) so it does not re-fire on subsequent startups.
+// A post-reboot cleanup in InstallMCR provides a second deletion attempt as
+// a fallback.
 //
 // TODO: move this fix upstream into the k0sproject/rig Windows configurer.
 func (c WindowsConfigurer) Reboot(h os.Host) error {

--- a/pkg/docker/image.go
+++ b/pkg/docker/image.go
@@ -95,7 +95,6 @@ func (i *Image) Exist(h *mkeconfig.Host) bool {
 // PullImages pulls multiple images parallelly by using a worker pool.
 func PullImages(h *mkeconfig.Host, images []*Image) error {
 	wp := workerpool.New(5)
-	defer wp.StopWait()
 
 	var mutex sync.Mutex
 	var lastError error
@@ -113,6 +112,10 @@ func PullImages(h *mkeconfig.Host, images []*Image) error {
 		})
 	}
 
+	// Wait for all workers to complete before reading lastError.
+	// A deferred StopWait() would let the return expression evaluate
+	// before workers finish, potentially returning nil on a real error.
+	wp.StopWait()
 	return lastError
 }
 

--- a/pkg/docker/image.go
+++ b/pkg/docker/image.go
@@ -103,16 +103,12 @@ func PullImages(h *mkeconfig.Host, images []*Image) error {
 	for _, image := range images {
 		i := image // So we can safely pass i forward to pool without it getting mutated
 		wp.Submit(func() {
-			mutex.Lock()
-			defer mutex.Unlock()
-			if lastError != nil {
-				return
-			}
-
-			err := i.Pull(h)
-			if err != nil {
+			if err := i.Pull(h); err != nil {
 				mutex.Lock()
-				lastError = err
+				if lastError == nil {
+					lastError = err
+				}
+				mutex.Unlock()
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fixes two bugs in the Windows MCR installation path and adds a reliable reboot mechanism.

### Bug 1: Exit code 3010 treated as hard failure

When the MCR installer exits with code 3010 (`ERROR_SUCCESS_REBOOT_REQUIRED`), rig wraps the non-zero exit as `ErrCommandFailed`. `InstallMCR` was returning immediately on any non-zero exit, so the reboot-detection logic was unreachable.

**Fix:** Intercept the error in `InstallMCR` via `isExitCode3010()` and treat it as a reboot-required signal instead of a hard failure.

### Bug 2: Successful reboot fell through to error return

After a successful `rh.Reboot()` call, execution fell through to the `errRebootRequired` return, making every successful reboot appear as a failure.

**Fix:** Return `nil` after a successful reboot.

### Bug 3: rig's Windows Reboot uses `shutdown /r /t 5`

rig's `Windows.Reboot()` issues `shutdown /r /t 5` which is silently ignored when Windows has a pending-reboot state (as is the case after a 3010 exit). The host never goes offline and the wait loop times out.

**Fix:** Override `Reboot()` on `WindowsConfigurer` to use `Restart-Computer -Force` via PowerShell, which bypasses pending-reboot locks.

A TODO comment marks this for upstreaming into k0sproject/rig.

### Additional fix: `GetInstaller` dead code

A dead-code branch in `GetInstaller` made the installer download path unreachable when no cached path existed.

**Fix:** Remove the unreachable branch.

## Files changed

| File | Change |
|---|---|
| `pkg/configurer/installer.go` | Remove dead-code branch blocking installer download |
| `pkg/configurer/common.go` | Hoist `rebootable` interface to package scope |
| `pkg/configurer/windows.go` | Handle exit 3010, fix reboot fall-through, override `Reboot()` with `Restart-Computer -Force` |

## Testing

End-to-end tested against fresh AWS infrastructure (1x Ubuntu 22.04 manager, 3x Windows workers: 2019/2022/2025) using the ENGINE1383 custom installer script.