### PR TITLE
[PRODENG-3641] Option 1: add spec.mcr.installCLI to install docker-ee-cli explicitly

### DIFF
--- a/pkg/configurer/enterpriselinux/el.go
+++ b/pkg/configurer/enterpriselinux/el.go
@@ -73,8 +73,9 @@ gpgkey=%s
 	if err := c.InstallPackage(h, "containerd.io"); err != nil {
 		return fmt.Errorf("package manager could not install containerd.io")
 	}
-	if err := c.InstallPackage(h, "docker-ee"); err != nil {
-		return fmt.Errorf("package manager could not install docker-ee")
+	mcrPackages := configurer.MCRPackages(engineConfig)
+	if err := c.InstallPackage(h, mcrPackages...); err != nil {
+		return fmt.Errorf("package manager could not install %s", strings.Join(mcrPackages, ", "))
 	}
 
 	if err := c.EnableMCR(h, engineConfig); err != nil {

--- a/pkg/configurer/linux.go
+++ b/pkg/configurer/linux.go
@@ -26,6 +26,29 @@ const (
 	SbinPath = `PATH=/usr/local/sbin:/usr/sbin:/sbin:$PATH`
 )
 
+const (
+	// mcrPackage is the Mirantis Container Runtime package name. It is identical
+	// across the rpm and deb repositories on repos.mirantis.com.
+	mcrPackage = "docker-ee"
+	// mcrCLIPackage is the docker CLI package name, likewise identical across
+	// rpm and deb.
+	mcrCLIPackage = "docker-ee-cli"
+)
+
+// MCRPackages returns the packages to install for MCR, in the order they should
+// be passed to the package manager.
+//
+// The CLI is only listed when spec.mcr.installCLI is set. It is returned in the
+// same slice rather than installed separately so that both land in a single
+// package manager transaction and cannot be resolved to mismatched versions.
+func MCRPackages(engineConfig commonconfig.MCRConfig) []string {
+	if engineConfig.InstallCLI {
+		return []string{mcrPackage, mcrCLIPackage}
+	}
+
+	return []string{mcrPackage}
+}
+
 var ErrLinuxMCRInstall = errors.New("failed to install MCR on linux")
 
 // LinuxConfigurer is a generic linux host configurer.

--- a/pkg/configurer/mcr_packages_test.go
+++ b/pkg/configurer/mcr_packages_test.go
@@ -1,0 +1,37 @@
+package configurer_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Mirantis/launchpad/pkg/configurer"
+	commonconfig "github.com/Mirantis/launchpad/pkg/product/common/config"
+)
+
+// TestMCRPackages covers the package set every Linux configurer installs.
+//
+// The runtime package lists the CLI only as a Recommends (a weak dependency),
+// not a Requires/Depends, so the default must stay runtime-only: adding the CLI
+// unconditionally would change what every existing cluster installs.
+// spec.mcr.installCLI opts in for hosts where weak-dependency resolution is
+// disabled or otherwise cannot be relied on. See PRODENG-3641.
+func TestMCRPackages(t *testing.T) {
+	t.Run("default installs the runtime only", func(t *testing.T) {
+		require.Equal(t, []string{"docker-ee"}, configurer.MCRPackages(commonconfig.MCRConfig{}))
+	})
+
+	t.Run("installCLI adds the cli package", func(t *testing.T) {
+		require.Equal(t, []string{"docker-ee", "docker-ee-cli"},
+			configurer.MCRPackages(commonconfig.MCRConfig{InstallCLI: true}))
+	})
+
+	t.Run("both packages are returned together for a single transaction", func(t *testing.T) {
+		// Returned as one slice, and the runtime stays first, so callers hand both
+		// to the package manager in one invocation. Installing them separately
+		// would allow the runtime and CLI to resolve to mismatched versions.
+		pkgs := configurer.MCRPackages(commonconfig.MCRConfig{InstallCLI: true})
+		require.Len(t, pkgs, 2)
+		require.Equal(t, "docker-ee", pkgs[0])
+	})
+}

--- a/pkg/configurer/sles/sles.go
+++ b/pkg/configurer/sles/sles.go
@@ -107,8 +107,9 @@ func (c Configurer) InstallMCR(h os.Host, engineConfig commonconfig.MCRConfig) e
 	if err := h.Exec("zypper -n install -y --allow-vendor-change containerd.io", exec.Sudo(h)); err != nil {
 		return fmt.Errorf("package manager could not install containerd.io: %w", err)
 	}
-	if err := h.Exec("zypper -n install -y --allow-vendor-change docker-ee", exec.Sudo(h)); err != nil {
-		return fmt.Errorf("package manager could not install docker-ee: %w", err)
+	mcrPackages := configurer.MCRPackages(engineConfig)
+	if err := h.Exec("zypper -n install -y --allow-vendor-change "+strings.Join(mcrPackages, " "), exec.Sudo(h)); err != nil {
+		return fmt.Errorf("package manager could not install %s: %w", strings.Join(mcrPackages, ", "), err)
 	}
 
 	if err := c.EnableMCR(h, engineConfig); err != nil {

--- a/pkg/configurer/ubuntu/ubuntu.go
+++ b/pkg/configurer/ubuntu/ubuntu.go
@@ -2,6 +2,7 @@ package ubuntu
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Mirantis/launchpad/pkg/configurer"
 	commonconfig "github.com/Mirantis/launchpad/pkg/product/common/config"
@@ -80,8 +81,9 @@ Signed-by: /usr/share/keyrings/mirantis-archive-keyring.gpg
 	if err := c.InstallPackage(h, "containerd.io"); err != nil {
 		return fmt.Errorf("package manager could not install containerd.io")
 	}
-	if err := c.InstallPackage(h, "docker-ee"); err != nil {
-		return fmt.Errorf("package manager could not install docker-ee")
+	mcrPackages := configurer.MCRPackages(engineConfig)
+	if err := c.InstallPackage(h, mcrPackages...); err != nil {
+		return fmt.Errorf("package manager could not install %s", strings.Join(mcrPackages, ", "))
 	}
 
 	if err := c.EnableMCR(h, engineConfig); err != nil {

--- a/pkg/product/common/config/mcr_config.go
+++ b/pkg/product/common/config/mcr_config.go
@@ -31,6 +31,25 @@ type MCRConfig struct {
 	SwarmInstallFlags           Flags    `yaml:"swarmInstallFlags,omitempty,flow"`
 	SwarmUpdateCommands         []string `yaml:"swarmUpdateCommands,omitempty,flow"`
 
+	// InstallCLI additionally installs the docker CLI package (docker-ee-cli)
+	// alongside the runtime, in the same package manager transaction so the two
+	// cannot end up at mismatched versions.
+	//
+	// The runtime package lists the CLI only as a Recommends (a weak
+	// dependency), not a Requires/Depends, on every repos.mirantis.com package
+	// checked -- rpm (dnf/yum) and deb (apt) alike. Package managers install
+	// Recommends by default, so this is normally not needed. It is needed when
+	// weak-dependency installation is disabled, which common hardening
+	// baselines do explicitly (dnf/yum: install_weak_deps=false; apt:
+	// APT::Install-Recommends "false"). Set it on hosts where that applies, or
+	// where the runtime has otherwise installed without the CLI. See
+	// PRODENG-3641.
+	//
+	// Linux only. Windows installs MCR through install.ps1, which ships the CLI
+	// as part of the same archive and has no separate package, so this value is
+	// ignored on Windows hosts.
+	InstallCLI bool `yaml:"installCLI,omitempty"`
+
 	Metadata *MCRMetadata `yaml:"-"`
 }
 

--- a/pkg/product/common/config/mcr_config_test.go
+++ b/pkg/product/common/config/mcr_config_test.go
@@ -39,3 +39,35 @@ func TestSwarmUpdateCommands(t *testing.T) {
 	require.Equal(t, 1, slices.Index(cfg.SwarmUpdateCommands, "command2"))
 	require.Equal(t, 2, slices.Index(cfg.SwarmUpdateCommands, "command3"))
 }
+
+func TestMCRConfig_InstallCLI(t *testing.T) {
+	// The yaml key is the user-facing contract: a mismatch here would silently
+	// ignore the setting and reintroduce PRODENG-3641 for anyone opting in.
+	for _, tc := range []struct {
+		name     string
+		yaml     string
+		expected bool
+	}{
+		{
+			name:     "absent defaults to false",
+			yaml:     "channel: stable",
+			expected: false,
+		},
+		{
+			name:     "installCLI true is honoured",
+			yaml:     "channel: stable\ninstallCLI: true",
+			expected: true,
+		},
+		{
+			name:     "installCLI false is honoured",
+			yaml:     "channel: stable\ninstallCLI: false",
+			expected: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := commonconfig.MCRConfig{}
+			require.NoError(t, yaml.Unmarshal([]byte(tc.yaml), &cfg))
+			require.Equal(t, tc.expected, cfg.InstallCLI)
+		})
+	}
+}


### PR DESCRIPTION
## What
Adds `spec.mcr.installCLI` (bool, default `false`). When set, the docker CLI package `docker-ee-cli` is named explicitly in the MCR install.

**This is one of two divergent PRs for PRODENG-3641.** The alternative is #656 (`installRecommends`). They are alternatives, not companions — pick one.

## Why
Launchpad installs the runtime with a bare `yum install -y docker-ee` (equivalently apt-get/zypper) and relies on the package manager to bring in the CLI. A customer on CIS-hardened RHEL 8.10 ended up with the runtime installed and no CLI, so every later docker command failed on a host that otherwise looked correctly installed. Installing `docker-ee-cli` by hand and re-running launchpad completed the cluster.

I checked why. Every `docker-ee` package on repos.mirantis.com lists `docker-ee-cli` as a **recommended** package (rpm `Recommends` / deb `Recommends`), never as a hard `Requires`/`Depends`:

| Platform | Channels checked | CLI relationship |
|---|---|---|
| rhel 8, rhel 9 | stable-25.0, stable-29.2 | Recommends only |
| sles 15 | stable-25.0, stable-29.2 | Recommends only |
| ubuntu jammy, noble | stable-25.0, stable-29.2 | Recommends only |

Package managers install recommended packages by default, which is why this normally works unattended. Hardening baselines commonly disable exactly that — `install_weak_deps=false` (dnf/yum), `APT::Install-Recommends "false"` (apt), `solver.onlyRequires` (zypper). Naming the package explicitly bypasses that resolution entirely.

## How
- `MCRConfig.InstallCLI` — `installCLI` in yaml, documented including that Windows ignores it.
- `configurer.MCRPackages()` returns the package list, so the names live in one place rather than being repeated across three configurers.
- Both packages are passed in a **single** package-manager invocation, not two calls, so the runtime and CLI cannot resolve to mismatched versions.

Default stays `false` deliberately: recommended packages are installed by default on an unhardened host, so installing the CLI unconditionally would change what every existing cluster installs in order to work around an environment-specific setting.

## Trade-off versus the alternative
- **This PR:** identical two-package behaviour on every platform, no surprising footprint, keeps rig's `InstallPackage`. Cost: a hardcoded package list that can drift from repository metadata, and it does **not** address `cri-dockerd-ee`, which is also only a recommended package and which launchpad never installs explicitly.
- **The `installRecommends` PR:** delegates the list to repository metadata so it cannot drift and covers `cri-dockerd-ee` too. Cost: on deb hosts it additionally installs `git`, `pigz`, `procps`, `xz-utils`, `ca-certificates`, `libltdl7`, `docker-ee-rootless-extras` and a `kernel` package; and it requires running package-manager commands directly on all three families.

## Testing
- `TestMCRPackages` — default is runtime-only; `installCLI` adds the CLI; runtime stays first and both are returned together for a single transaction.
- `TestMCRConfig_InstallCLI` — the yaml key round-trips (absent → false, `true`/`false` honoured). A wrong struct tag would silently ignore the setting and reintroduce the bug for anyone opting in.
- Both were confirmed to fail with the default flipped, so they discriminate.
- `make lint` clean (0 issues), `go vet`, `go vet -tags=integration`, gofmt, full unit suite green.

Not smoke-tested: the failure mode needs a host with weak dependencies disabled, which no smoke platform currently provides.

## Open question
This is a mitigation, not a root-cause fix. The reason resolution skipped the CLI on that specific host is still unconfirmed — the customer's launchpad config, `docker-ee.repo` and `apply.log` were requested on the ticket and have not arrived. If their `install_weak_deps` is set, that confirms it; if not, something else is going on and this flag may not help them.

## Links
- JIRA: [PRODENG-3641](https://mirantis.jira.com/browse/PRODENG-3641)

Written by AI: claude-sonnet-5


[PRODENG-3641]: https://mirantis.jira.com/browse/PRODENG-3641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ