### PR TITLE
[PRODENG-3642] Validate pod CIDR against the live Swarm overlay address pool

### DIFF
--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -130,3 +130,27 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: make smoke-upgrade
+
+  # PRODENG-3642. Deliberately omits the `push` trigger and the broad
+  # `smoke-test` label: this spends a stack on validation logic that changes
+  # rarely, so it is run when that logic is touched rather than every merge.
+  smoke-swarm-pool:
+    runs-on: arc-runner-set-mirantis-public
+    if: contains(github.event.pull_request.labels.*.name, 'smoke-swarm-pool')
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
+      - name: Run swarm address pool smoke test
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: make smoke-swarm-pool

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,9 @@ smoke-fips:
 .PHONY: smoke-upgrade
 smoke-upgrade:
 	go test -count=1 -v ./test/smoke/... -run TestUpgrade -timeout 90m
+.PHONY: smoke-swarm-pool
+smoke-swarm-pool:
+	go test -count=1 -v ./test/smoke/... -run TestSwarmAddrPoolCluster -timeout 60m
 .PHONY: clean-launchpad-chart
 clean-launchpad-chart:
 	terraform -chdir=./examples/tf-aws/launchpad apply --auto-approve --destroy

--- a/docs/usage/swarm-overlay-address-pool.md
+++ b/docs/usage/swarm-overlay-address-pool.md
@@ -1,0 +1,98 @@
+# Swarm overlay address pool
+
+Swarm allocates the subnets for overlay networks — including `ingress` — from its
+default address pool. Unless a pool was given when the swarm was created, that
+pool is `10.0.0.0/8` with a 24-bit subnet mask, so `ingress` becomes `10.0.0.0/24`.
+
+## The pool cannot be changed after the swarm is created
+
+`--default-addr-pool` is accepted only by `docker swarm init`. It is not part of
+the swarm specification that `docker swarm update` modifies, so there is no
+command that changes the pool of a running swarm:
+
+```
+$ docker swarm update --default-addr-pool 10.10.0.0/16
+unknown flag: --default-addr-pool
+```
+
+Launchpad passes `spec.mcr.swarmInstallFlags` to `docker swarm init`, which means
+those flags take effect only on the run that creates the swarm. On any later run
+against an existing cluster they are ignored, and launchpad logs a warning
+naming them.
+
+Setting `--default-addr-pool` on a cluster whose swarm already exists therefore
+changes nothing on the hosts. Launchpad reports this as a warning:
+
+```
+mcr.swarmInstallFlags sets --default-addr-pool 10.0.0.0/16 but the existing swarm
+allocates overlay networks from 10.0.0.0/8. A swarm's address pool is fixed when
+the swarm is created and cannot be changed on a running cluster, so this setting
+has no effect here and the cluster no longer matches its configuration.
+```
+
+## Reading the pool a cluster is using
+
+On a manager:
+
+```bash
+docker info --format '{{.Swarm.LocalNodeState}}|{{if .Swarm.Cluster}}{{range .Swarm.Cluster.DefaultAddrPool}}{{.}} {{end}}{{end}}'
+```
+
+An empty pool list means the swarm was created without `--default-addr-pool` and
+is using the `10.0.0.0/8` default. The subnet mask length is
+`{{.Swarm.Cluster.SubnetSize}}`.
+
+The `ingress` network is allocated from the pool and confirms it independently:
+
+```bash
+docker network inspect ingress --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}'
+```
+
+## Overlap with the Kubernetes pod CIDR
+
+`--pod-cidr` in `spec.mke.installFlags` must not overlap the Swarm pool.
+An overlap can leave the container runtime with a broken network configuration
+during MKE bootstrap, which drops the SSH connection and surfaces as a
+connection timeout after 20 or more minutes.
+
+Launchpad checks this in the `Validate Facts` phase, and what it does depends on
+whether the conflict is still avoidable:
+
+| Cluster state | Pool compared against | On overlap |
+|---|---|---|
+| No swarm yet | `spec.mcr.swarmInstallFlags`, or `10.0.0.0/8` | Fails. Choose a non-overlapping `--pod-cidr`, or set `--default-addr-pool`, which will be applied. |
+| Swarm exists | The pool read from the swarm | Warns and continues. The pool cannot be changed, so failing would only block upgrades of clusters already running this way. |
+
+## Changing the pool on an existing cluster
+
+There is no non-destructive procedure. The swarm must be dissolved and
+re-created, which **destroys every overlay network and every service running on
+them**, including `ingress`. Plan a maintenance window.
+
+If the goal is only to resolve a pod CIDR overlap, changing `--pod-cidr` instead
+is far less disruptive and is the recommended option.
+
+To change the pool:
+
+1. Record the current configuration — `docker network ls`, and
+   `docker network inspect` for each overlay network you will need to re-create.
+2. Stop workloads that depend on overlay networking.
+3. On every node, leave the swarm: `docker swarm leave --force`.
+4. Set the desired pool in the cluster configuration:
+
+   ```yaml
+   spec:
+     mcr:
+       swarmInstallFlags:
+         - --default-addr-pool=10.10.0.0/16
+         - --default-addr-pool-mask-length=24
+   ```
+
+5. Run `launchpad apply`. With no swarm present, `InitSwarm` creates one and the
+   flags are applied.
+6. Confirm the new pool with the `docker info` command above, and check that
+   `ingress` has been allocated from it.
+7. Re-create the overlay networks and redeploy the workloads recorded in step 1.
+
+`--default-addr-pool` may be repeated to give the swarm more than one pool.
+Launchpad validates `--pod-cidr` against all of them.

--- a/pkg/product/common/config/mcr_config.go
+++ b/pkg/product/common/config/mcr_config.go
@@ -60,6 +60,11 @@ type MCRMetadata struct {
 	ManagerJoinToken string
 	WorkerJoinToken  string
 	MCRChannel       string
+	// SwarmDefaultAddrPool holds the overlay address pools an already existing
+	// swarm allocates from, as discovered on the swarm leader. It is empty when
+	// no swarm exists yet, so a non-empty value means the swarm predates this
+	// run and its pool can no longer be changed. See PRODENG-3642.
+	SwarmDefaultAddrPool []string
 }
 
 // UnmarshalYAML puts in sane defaults when unmarshaling from yaml.

--- a/pkg/product/mke/phase/gather_facts.go
+++ b/pkg/product/mke/phase/gather_facts.go
@@ -60,6 +60,17 @@ func (p *GatherFacts) Run() error {
 			log.Infof("%s: MKE is not installed", swarmLeader)
 		}
 		p.Config.Spec.MKE.Metadata.ClusterID = swarm.ClusterID(swarmLeader)
+
+		// The overlay address pool of an existing swarm is needed by
+		// ValidateFacts, which runs before MCR is installed and so cannot read
+		// it from a host itself. A read failure is not fatal: validation falls
+		// back to the configured pool.
+		pools, err := swarm.DefaultAddrPool(swarmLeader)
+		if err != nil {
+			log.Warnf("%s: failed to read the swarm overlay address pool: %s", swarmLeader, err.Error())
+		} else if p.Config.Spec.MCR.Metadata != nil {
+			p.Config.Spec.MCR.Metadata.SwarmDefaultAddrPool = pools
+		}
 	}
 	if p.Config.Spec.ContainsMSR() {
 		// If we intend to configure msr as well, gather facts for msr

--- a/pkg/product/mke/phase/init_swarm.go
+++ b/pkg/product/mke/phase/init_swarm.go
@@ -45,7 +45,12 @@ func (p *InitSwarm) Run() error {
 	} else {
 		log.Infof("%s: swarm already initialized", swarmLeader)
 		if len(p.Config.Spec.MCR.SwarmInstallFlags) > 0 {
-			log.Warnf("%s: swarm install flags ignored due to swarm cluster already existing", swarmLeader)
+			// Naming the flags matters: these are settings the operator believes
+			// are in force, and several of them (--default-addr-pool in
+			// particular) cannot be applied to a swarm after it exists.
+			// See PRODENG-3642.
+			log.Warnf("%s: swarm install flags only apply when a swarm is created, so %q has no effect on this cluster",
+				swarmLeader, p.Config.Spec.MCR.SwarmInstallFlags.Join())
 		}
 	}
 

--- a/pkg/product/mke/phase/validate_facts.go
+++ b/pkg/product/mke/phase/validate_facts.go
@@ -4,11 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/Mirantis/launchpad/pkg/mke"
 	"github.com/Mirantis/launchpad/pkg/phase"
 	mkeconfig "github.com/Mirantis/launchpad/pkg/product/mke/config"
+	"github.com/Mirantis/launchpad/pkg/swarm"
 	"github.com/hashicorp/go-version"
 	log "github.com/sirupsen/logrus"
 )
@@ -69,6 +72,8 @@ func (p *ValidateFacts) Run() error {
 			return errors.Join(ErrFactsArentValid, err)
 		}
 	}
+
+	p.warnSwarmAddrPoolDivergence()
 
 	if err := p.validatePodCIDR(); err != nil {
 		return errors.Join(ErrFactsArentValid, err)
@@ -203,16 +208,67 @@ func (p *ValidateFacts) validateDataPlane() error {
 
 var errInvalidPodCIDR = errors.New("invalid pod CIDR configuration")
 
-// swarmDefaultAddrPool is the Docker Swarm default overlay address pool.
-const swarmDefaultAddrPool = "10.0.0.0/8"
-
-// validatePodCIDR checks that --pod-cidr in mke.installFlags does not overlap
-// with the Swarm overlay address pool. Overlapping CIDRs cause the Docker daemon
-// to restart into a broken network state during MKE bootstrap, which silently
-// drops the SSH connection and produces a connection timeout after 20+ minutes.
+// swarmAddrPools returns the overlay address pools that --pod-cidr must not
+// overlap, and whether they describe a swarm that already exists.
 //
-// If mcr.swarmInstallFlags contains --default-addr-pool, that value is used as
-// the Swarm pool instead of the compiled-in default (10.0.0.0/8).
+// An existing swarm is authoritative. Its pool is fixed at creation and the
+// InitSwarm phase discards mcr.swarmInstallFlags on such a cluster, so the
+// configured value describes nothing there. Before a swarm exists the configured
+// value is what swarm init will apply, and so is the pool to validate against.
+func (p *ValidateFacts) swarmAddrPools() (pools []string, fromExistingSwarm bool) {
+	if p.Config.Spec.MCR.Metadata != nil && len(p.Config.Spec.MCR.Metadata.SwarmDefaultAddrPool) > 0 {
+		return p.Config.Spec.MCR.Metadata.SwarmDefaultAddrPool, true
+	}
+
+	// docker swarm init accepts --default-addr-pool repeated, so keep every pool.
+	if configured := p.Config.Spec.MCR.SwarmInstallFlags.GetValues("--default-addr-pool"); len(configured) > 0 {
+		return configured, false
+	}
+
+	return []string{swarm.DefaultAddrPoolFallback}, false
+}
+
+// warnSwarmAddrPoolDivergence reports an mcr.swarmInstallFlags --default-addr-pool
+// setting that describes something other than the running cluster. The pool is
+// fixed when the swarm is created, so on an existing cluster the setting is inert
+// and the configuration quietly stops matching the infrastructure.
+//
+// Nothing is reported unless a pool is both explicitly configured and known to
+// differ from the live one, so the common case of a cluster that never set the
+// flag stays silent.
+func (p *ValidateFacts) warnSwarmAddrPoolDivergence() {
+	if p.Config.Spec.MCR.Metadata == nil || len(p.Config.Spec.MCR.Metadata.SwarmDefaultAddrPool) == 0 {
+		return
+	}
+
+	configured := p.Config.Spec.MCR.SwarmInstallFlags.GetValues("--default-addr-pool")
+	if len(configured) == 0 {
+		return
+	}
+
+	live := p.Config.Spec.MCR.Metadata.SwarmDefaultAddrPool
+	if slices.Equal(configured, live) {
+		return
+	}
+
+	log.Warnf(
+		"mcr.swarmInstallFlags sets --default-addr-pool %s but the existing swarm allocates overlay networks from %s. "+
+			"A swarm's address pool is fixed when the swarm is created and cannot be changed on a running cluster, so this "+
+			"setting has no effect here and the cluster no longer matches its configuration. Changing the pool requires "+
+			"dissolving and re-creating the swarm, which destroys every overlay network and service",
+		strings.Join(configured, ","), strings.Join(live, ","),
+	)
+}
+
+// validatePodCIDR checks that --pod-cidr in mke.installFlags does not overlap the
+// Swarm overlay address pool. Overlapping CIDRs cause the Docker daemon to restart
+// into a broken network state during MKE bootstrap, which silently drops the SSH
+// connection and produces a connection timeout after 20+ minutes.
+//
+// The conflict is fatal only while it is still avoidable, which means before the
+// swarm exists. On an existing swarm the pool cannot be changed, so the conflict
+// is reported and the run continues rather than blocking upgrades of clusters that
+// are already running this way. See PRODENG-3642.
 func (p *ValidateFacts) validatePodCIDR() error {
 	podCIDRStr := p.Config.Spec.MKE.InstallFlags.GetValue("--pod-cidr")
 	if podCIDRStr == "" {
@@ -224,28 +280,48 @@ func (p *ValidateFacts) validatePodCIDR() error {
 		return fmt.Errorf("%w: cannot parse --pod-cidr %q: %w", errInvalidPodCIDR, podCIDRStr, err)
 	}
 
-	// docker swarm init accepts --default-addr-pool repeated, so check every
-	// pool. Fall back to the compiled-in default when none is configured.
-	swarmPools := p.Config.Spec.MCR.SwarmInstallFlags.GetValues("--default-addr-pool")
-	if len(swarmPools) == 0 {
-		swarmPools = []string{swarmDefaultAddrPool}
-	}
+	swarmPools, fromExistingSwarm := p.swarmAddrPools()
+	overlapping := false
 
 	for _, swarmPoolStr := range swarmPools {
 		_, swarmNet, err := net.ParseCIDR(swarmPoolStr)
 		if err != nil {
+			if fromExistingSwarm {
+				// Reported by the daemon rather than written by the user, so
+				// there is nothing in the configuration to correct.
+				log.Warnf("cannot parse the overlay address pool %q reported by the existing swarm: %s", swarmPoolStr, err.Error())
+				continue
+			}
+
 			return fmt.Errorf("%w: cannot parse Swarm address pool %q: %w", errInvalidPodCIDR, swarmPoolStr, err)
 		}
 
-		if swarmNet.Contains(podNet.IP) || podNet.Contains(swarmNet.IP) {
+		if !swarmNet.Contains(podNet.IP) && !podNet.Contains(swarmNet.IP) {
+			continue
+		}
+
+		if !fromExistingSwarm {
 			return fmt.Errorf(
 				"%w: --pod-cidr %s overlaps with the Swarm overlay address pool %s; "+
 					"choose a non-overlapping range or set mcr.swarmInstallFlags --default-addr-pool to a non-conflicting pool",
 				errInvalidPodCIDR, podCIDRStr, swarmPoolStr,
 			)
 		}
+
+		overlapping = true
+
+		log.Warnf(
+			"--pod-cidr %s overlaps the overlay address pool %s of the existing swarm, which can leave the container "+
+				"runtime with a broken network configuration during MKE bootstrap. The pool is fixed when a swarm is "+
+				"created, so mcr.swarmInstallFlags cannot resolve this on a running cluster: either choose a "+
+				"non-overlapping --pod-cidr, or dissolve and re-create the swarm with a non-overlapping pool",
+			podCIDRStr, swarmPoolStr,
+		)
 	}
 
-	log.Debugf("pod CIDR %s does not overlap with any Swarm pool %v", podCIDRStr, swarmPools)
+	if !overlapping {
+		log.Debugf("pod CIDR %s does not overlap with any Swarm pool %v", podCIDRStr, swarmPools)
+	}
+
 	return nil
 }

--- a/pkg/product/mke/phase/validate_facts_test.go
+++ b/pkg/product/mke/phase/validate_facts_test.go
@@ -1,12 +1,14 @@
 package phase
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
 	commonconfig "github.com/Mirantis/launchpad/pkg/product/common/config"
 	mkeconfig "github.com/Mirantis/launchpad/pkg/product/mke/config"
 	"github.com/k0sproject/rig"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -349,4 +351,146 @@ func TestValidatePodCIDRMalformedSwarmPool(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, errInvalidPodCIDR)
 	require.ErrorContains(t, err, "cannot parse Swarm address pool")
+}
+
+// --- swarm overlay address pool (PRODENG-3642) -------------------------------
+
+// podCIDRPhase builds a ValidateFacts phase for the pod CIDR checks. A nil
+// livePools means no existing swarm was discovered, i.e. a first install.
+func podCIDRPhase(podCIDR string, configuredPools, livePools []string) ValidateFacts {
+	installFlags := commonconfig.Flags{}
+	if podCIDR != "" {
+		installFlags = append(installFlags, "--pod-cidr="+podCIDR)
+	}
+
+	swarmFlags := commonconfig.Flags{}
+	for _, pool := range configuredPools {
+		swarmFlags = append(swarmFlags, "--default-addr-pool="+pool)
+	}
+
+	phase := ValidateFacts{}
+	phase.Config = &mkeconfig.ClusterConfig{
+		Spec: &mkeconfig.ClusterSpec{
+			MKE: mkeconfig.MKEConfig{InstallFlags: installFlags},
+			MCR: commonconfig.MCRConfig{
+				SwarmInstallFlags: swarmFlags,
+				Metadata:          &commonconfig.MCRMetadata{SwarmDefaultAddrPool: livePools},
+			},
+		},
+	}
+
+	return phase
+}
+
+// captureLogs returns everything fn logs, so warn-only behaviour is observable.
+func captureLogs(t *testing.T, fn func()) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	logger := logrus.StandardLogger()
+	originalOut, originalLevel := logger.Out, logger.GetLevel()
+	logger.SetOutput(&buf)
+	logger.SetLevel(logrus.DebugLevel)
+
+	t.Cleanup(func() {
+		logger.SetOutput(originalOut)
+		logger.SetLevel(originalLevel)
+	})
+
+	fn()
+
+	return buf.String()
+}
+
+// The reported bug: on an existing swarm the configured pool is discarded by
+// InitSwarm, so validating against it hides a live overlap. The overlap must be
+// reported, and must not block a cluster that already runs this way.
+func TestValidatePodCIDRWarnsOnLiveOverlapHiddenByConfiguredPool(t *testing.T) {
+	phase := podCIDRPhase("10.244.0.0/16", []string{"10.0.0.0/16"}, []string{"10.0.0.0/8"})
+
+	var err error
+	out := captureLogs(t, func() { err = phase.validatePodCIDR() })
+
+	require.NoError(t, err, "the pool of an existing swarm cannot be changed, so this must not fail the run")
+	require.Contains(t, out, "--pod-cidr 10.244.0.0/16 overlaps the overlay address pool 10.0.0.0/8 of the existing swarm")
+	require.Contains(t, out, "cannot resolve this on a running cluster")
+}
+
+// The live pool takes precedence: this configuration would pass on its own.
+func TestValidatePodCIDRPrefersLivePoolOverConfiguredPool(t *testing.T) {
+	phase := podCIDRPhase("10.244.0.0/16", []string{"10.10.0.0/16"}, []string{"10.244.0.0/16"})
+
+	var err error
+	out := captureLogs(t, func() { err = phase.validatePodCIDR() })
+
+	require.NoError(t, err)
+	require.Contains(t, out, "of the existing swarm")
+}
+
+// A swarm may hold several pools; all of them are checked.
+func TestValidatePodCIDRChecksEveryLivePool(t *testing.T) {
+	phase := podCIDRPhase("10.244.0.0/16", nil, []string{"10.10.0.0/16", "10.244.0.0/16"})
+
+	var err error
+	out := captureLogs(t, func() { err = phase.validatePodCIDR() })
+
+	require.NoError(t, err)
+	require.Contains(t, out, "overlay address pool 10.244.0.0/16")
+}
+
+func TestValidatePodCIDRSilentWhenLivePoolDoesNotOverlap(t *testing.T) {
+	phase := podCIDRPhase("10.244.0.0/16", nil, []string{"10.10.0.0/16"})
+
+	var err error
+	out := captureLogs(t, func() { err = phase.validatePodCIDR() })
+
+	require.NoError(t, err)
+	require.NotContains(t, out, "of the existing swarm")
+}
+
+// Metadata is populated from yaml and can be absent when a config is built by
+// hand; the check must fall back to the configured pool rather than panic.
+func TestValidatePodCIDRToleratesMissingMCRMetadata(t *testing.T) {
+	phase := podCIDRPhase("10.244.0.0/16", nil, nil)
+	phase.Config.Spec.MCR.Metadata = nil
+
+	require.ErrorContains(t, phase.validatePodCIDR(), "10.0.0.0/8")
+}
+
+// A pool configured on an existing swarm changes nothing on the hosts, which is
+// what makes the cluster stop matching its configuration.
+func TestWarnSwarmAddrPoolDivergenceReportsInertSetting(t *testing.T) {
+	phase := podCIDRPhase("", []string{"10.0.0.0/16"}, []string{"10.0.0.0/8"})
+
+	out := captureLogs(t, phase.warnSwarmAddrPoolDivergence)
+
+	require.Contains(t, out, "sets --default-addr-pool 10.0.0.0/16 but the existing swarm allocates overlay networks from 10.0.0.0/8")
+	require.Contains(t, out, "has no effect here")
+}
+
+// The ordinary case: no pool configured and a swarm on the default. Comparing an
+// empty configuration against the fallback would warn on every apply of every
+// cluster that never set the flag.
+func TestWarnSwarmAddrPoolDivergenceSilentWhenPoolNotConfigured(t *testing.T) {
+	phase := podCIDRPhase("", nil, []string{"10.0.0.0/8"})
+	require.Empty(t, captureLogs(t, phase.warnSwarmAddrPoolDivergence))
+}
+
+func TestWarnSwarmAddrPoolDivergenceSilentWhenConfigMatchesSwarm(t *testing.T) {
+	phase := podCIDRPhase("", []string{"10.10.0.0/16"}, []string{"10.10.0.0/16"})
+	require.Empty(t, captureLogs(t, phase.warnSwarmAddrPoolDivergence))
+}
+
+// On a first install there is no swarm to diverge from and the flags will be
+// applied, so there is nothing to report.
+func TestWarnSwarmAddrPoolDivergenceSilentOnFirstInstall(t *testing.T) {
+	phase := podCIDRPhase("", []string{"10.10.0.0/16"}, nil)
+	require.Empty(t, captureLogs(t, phase.warnSwarmAddrPoolDivergence))
+}
+
+func TestWarnSwarmAddrPoolDivergenceToleratesMissingMCRMetadata(t *testing.T) {
+	phase := podCIDRPhase("", []string{"10.10.0.0/16"}, nil)
+	phase.Config.Spec.MCR.Metadata = nil
+
+	require.Empty(t, captureLogs(t, phase.warnSwarmAddrPoolDivergence))
 }

--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -2,6 +2,7 @@ package swarm
 
 import (
 	"fmt"
+	"strings"
 
 	mkeconfig "github.com/Mirantis/launchpad/pkg/product/mke/config"
 	log "github.com/sirupsen/logrus"
@@ -40,4 +41,43 @@ func ClusterID(h *mkeconfig.Host) string {
 	}
 
 	return output
+}
+
+// DefaultAddrPoolFallback is the overlay address pool Docker uses when a swarm
+// was created without --default-addr-pool. Docker does not report a pool in that
+// case, so this value is what such a cluster is actually running with.
+const DefaultAddrPoolFallback = "10.0.0.0/8"
+
+// DefaultAddrPool returns the overlay address pools in effect for the swarm the
+// given host belongs to, or nil when the host is not part of a swarm.
+//
+// The pool is fixed when the swarm is created and cannot be changed afterwards:
+// --default-addr-pool is a field of docker's swarm InitRequest but not of the
+// Spec that "docker swarm update" mutates. Changing it requires dissolving and
+// re-creating the swarm, which destroys every overlay network and service.
+//
+// A swarm created without the flag reports an empty pool list, in which case
+// DefaultAddrPoolFallback is returned, so a non-empty result means "this host is
+// in a swarm and these are the pools it allocates overlay networks from".
+func DefaultAddrPool(h *mkeconfig.Host) ([]string, error) {
+	// The swarm state is read in the same call so that "not in a swarm" is
+	// distinguishable from "in a swarm with no explicit pool". Cluster is nil
+	// outside a swarm and dereferencing it fails the whole template, hence the
+	// guard.
+	out, err := h.ExecOutput(h.Configurer.DockerCommandf(
+		`info --format "{{.Swarm.LocalNodeState}}|{{if .Swarm.Cluster}}{{range .Swarm.Cluster.DefaultAddrPool}}{{.}} {{end}}{{end}}"`))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get swarm overlay address pool: %w", err)
+	}
+
+	state, pools, _ := strings.Cut(out, "|")
+	if strings.TrimSpace(state) != "active" {
+		return nil, nil
+	}
+
+	if configured := strings.Fields(pools); len(configured) > 0 {
+		return configured, nil
+	}
+
+	return []string{DefaultAddrPoolFallback}, nil
 }

--- a/pkg/swarm/swarm.go
+++ b/pkg/swarm/swarm.go
@@ -60,24 +60,31 @@ const DefaultAddrPoolFallback = "10.0.0.0/8"
 // DefaultAddrPoolFallback is returned, so a non-empty result means "this host is
 // in a swarm and these are the pools it allocates overlay networks from".
 func DefaultAddrPool(h *mkeconfig.Host) ([]string, error) {
-	// The swarm state is read in the same call so that "not in a swarm" is
-	// distinguishable from "in a swarm with no explicit pool". Cluster is nil
-	// outside a swarm and dereferencing it fails the whole template, hence the
-	// guard.
-	out, err := h.ExecOutput(h.Configurer.DockerCommandf(
-		`info --format "{{.Swarm.LocalNodeState}}|{{if .Swarm.Cluster}}{{range .Swarm.Cluster.DefaultAddrPool}}{{.}} {{end}}{{end}}"`))
+	out, err := h.ExecOutput(h.Configurer.DockerCommandf(defaultAddrPoolCmd))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get swarm overlay address pool: %w", err)
 	}
 
+	return parseDefaultAddrPool(out), nil
+}
+
+// defaultAddrPoolCmd reports the swarm state alongside the pools, so that "not in
+// a swarm" stays distinguishable from "in a swarm with no explicit pool". Cluster
+// is nil outside a swarm and dereferencing it fails the whole template, hence the
+// guard.
+const defaultAddrPoolCmd = `info --format "{{.Swarm.LocalNodeState}}|{{if .Swarm.Cluster}}{{range .Swarm.Cluster.DefaultAddrPool}}{{.}} {{end}}{{end}}"`
+
+// parseDefaultAddrPool turns the output of defaultAddrPoolCmd into the pools in
+// effect, or nil when the host is not in a swarm.
+func parseDefaultAddrPool(out string) []string {
 	state, pools, _ := strings.Cut(out, "|")
 	if strings.TrimSpace(state) != "active" {
-		return nil, nil
+		return nil
 	}
 
 	if configured := strings.Fields(pools); len(configured) > 0 {
-		return configured, nil
+		return configured
 	}
 
-	return []string{DefaultAddrPoolFallback}, nil
+	return []string{DefaultAddrPoolFallback}
 }

--- a/pkg/swarm/swarm_test.go
+++ b/pkg/swarm/swarm_test.go
@@ -1,0 +1,71 @@
+package swarm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The inputs below are the verbatim output of defaultAddrPoolCmd captured from
+// MCR 29.1.3, so a change in docker's rendering fails these rather than silently
+// mis-parsing on a live cluster.
+func TestParseDefaultAddrPool(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		out  string
+		want []string
+	}{
+		{
+			// Not in a swarm: the pool is unknown rather than defaulted, so
+			// callers can tell a greenfield host from a configured one.
+			name: "host is not in a swarm",
+			out:  "inactive|",
+			want: nil,
+		},
+		{
+			// A swarm created without --default-addr-pool reports no pool but is
+			// running on docker's built-in default.
+			name: "swarm without an explicit pool uses the built-in default",
+			out:  "active|",
+			want: []string{DefaultAddrPoolFallback},
+		},
+		{
+			name: "swarm with one pool",
+			out:  "active|10.10.0.0/16 ",
+			want: []string{"10.10.0.0/16"},
+		},
+		{
+			// --default-addr-pool may be repeated; every pool has to survive.
+			name: "swarm with repeated pools",
+			out:  "active|10.10.0.0/16 172.31.0.0/16 ",
+			want: []string{"10.10.0.0/16", "172.31.0.0/16"},
+		},
+		{
+			name: "pending state is not treated as a swarm",
+			out:  "pending|",
+			want: nil,
+		},
+		{
+			// A locked manager cannot be read from, and reporting the fallback
+			// would assert a pool that was never observed.
+			name: "locked state is not treated as a swarm",
+			out:  "locked|",
+			want: nil,
+		},
+		{
+			name: "surrounding whitespace is tolerated",
+			out:  "  active |  10.10.0.0/16  ",
+			want: []string{"10.10.0.0/16"},
+		},
+		{
+			// Defensive: an unexpectedly empty read must not claim a pool.
+			name: "empty output",
+			out:  "",
+			want: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, parseDefaultAddrPool(tc.out))
+		})
+	}
+}

--- a/test/smoke/swarm_addr_pool_test.go
+++ b/test/smoke/swarm_addr_pool_test.go
@@ -111,16 +111,26 @@ func TestSwarmAddrPoolCluster(t *testing.T) {
 		"a fresh install has no existing swarm to report against")
 
 	// ── Step 3: the configured pool must actually be in force ────────────────
-	// GatherFacts only reads the pool when a swarm already exists, so this
-	// second apply is what observes the result of step 2. Anything other than
-	// poolOutsideVPC here means swarm init ignored the flag.
+	// GatherFacts only reads the pool when a swarm already exists, so a second
+	// apply is what observes the result of step 2. Anything other than
+	// poolOutsideVPC below means swarm init ignored the flag.
 	verifyProduct, err := config.ProductFromYAML([]byte(installYAML))
 	require.NoError(t, err, "re-parse install launchpad YAML")
 
 	verifyLogs := captureLaunchpadLogs(t, func() {
 		err = verifyProduct.Apply(true, true, 3, true)
 	})
-	assert.NoError(t, err, "re-applying an unchanged config must succeed")
+
+	// This apply is a means of triggering discovery, not the behaviour under
+	// test. Gather Facts runs early, so the assertions below are already
+	// decided by the time anything later in the run can fail -- and those later
+	// phases install packages from public mirrors, which is a flake surface this
+	// test has no reason to inherit. A genuine failure to discover the pool
+	// still fails, on the assertion that actually checks it.
+	if err != nil {
+		t.Logf("re-apply did not run to completion; this does not affect the "+
+			"assertions below, which only need the Gather Facts phase: %v", err)
+	}
 
 	assert.Equal(t, []string{poolOutsideVPC}, discoveredAddrPool(t, verifyProduct),
 		"swarm init must have applied the configured pool")

--- a/test/smoke/swarm_addr_pool_test.go
+++ b/test/smoke/swarm_addr_pool_test.go
@@ -1,0 +1,299 @@
+package smoke_test
+
+// Swarm overlay address pool smoke coverage for PRODENG-3642.
+//
+// A swarm's --default-addr-pool is fixed when the swarm is created: it is a
+// field of docker's swarm InitRequest but not of the Spec that
+// "docker swarm update" mutates. Launchpad therefore validates --pod-cidr
+// against the pool the running swarm actually uses, and only against
+// spec.mcr.swarmInstallFlags when no swarm exists yet.
+//
+// Two things can only be demonstrated against a real cluster, and are covered
+// here rather than in pkg/product/mke/phase unit tests:
+//
+//   - a conflict is fatal while it is still avoidable, i.e. before the swarm
+//     exists, and configuring a pool genuinely resolves it
+//   - swarm init really does apply the configured pool, so a later apply
+//     discovers that pool rather than docker's default
+//
+// The warn-not-fail behaviour on an existing swarm is asserted in
+// upgrade_test.go, where CI already applies twice against one cluster.
+//
+// This test is label-gated and is not part of the per-merge matrix: it spends a
+// stack purely on validation logic that changes rarely.
+//
+// Provisioning is duplicated from runSmokeTest rather than shared. That is
+// deliberate: runSmokeTest's "defer terraform.Destroy" ordering is what keeps
+// failed runs from leaking VPCs (PRODENG-3631), and reshaping it to be reusable
+// would put the teardown of four existing smoke tests at risk to save ~40 lines.
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/Mirantis/launchpad/pkg/config"
+	"github.com/Mirantis/launchpad/pkg/product"
+	"github.com/Mirantis/launchpad/pkg/product/mke"
+	"github.com/Mirantis/launchpad/pkg/swarm"
+	"github.com/Mirantis/launchpad/test"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	// poolOutsideVPC is a pool the stack's 172.31.0.0/16 VPC does not contain,
+	// so configuring it cannot break host networking, and which docker's
+	// 10.0.0.0/8 default does contain, so a swarm created with it is
+	// distinguishable from a swarm created without one.
+	poolOutsideVPC = "10.99.0.0/16"
+
+	// podCIDRConflictingWithDefault is the customer's value from PRODENG-3642.
+	// It overlaps docker's default pool and not poolOutsideVPC.
+	podCIDRConflictingWithDefault = "10.244.0.0/16"
+)
+
+// TestSwarmAddrPoolCluster covers the install side of PRODENG-3642 on one stack:
+// the conflict is refused while it is still preventable, configuring a pool
+// resolves it, and the pool is genuinely in force afterwards.
+func TestSwarmAddrPoolCluster(t *testing.T) {
+	cfg := smokeConfig{
+		Name:            "swarmpool",
+		MCRChannel:      "stable-29.2",
+		MKEVersion:      "3.9.2",
+		MSRVersion:      "3.1.18",
+		SSHKeyAlgorithm: "ed25519",
+		// Two hosts is the smallest cluster that still exercises a real swarm.
+		Nodegroups: map[string]interface{}{
+			"MngrUbuntu24": test.Platforms["Ubuntu24"].GetManager(),
+			"WrkUbuntu24":  test.Platforms["Ubuntu24"].GetWorker(),
+		},
+	}
+
+	baseYAML := provisionSwarmPoolStack(t, cfg)
+
+	// ── Step 1: the conflict must be refused, not worked around ──────────────
+	// No pool is configured, so validation compares against docker's default
+	// and must fail. This costs nothing beyond a connect and fact-gather: the
+	// run aborts in Validate Facts, long before MKE is installed, so the broken
+	// network state the check exists to prevent is never created.
+	conflictingYAML, err := setSwarmPoolAndPodCIDR(baseYAML, "", podCIDRConflictingWithDefault)
+	require.NoError(t, err, "inject conflicting pod CIDR")
+
+	conflictingProduct, err := config.ProductFromYAML([]byte(conflictingYAML))
+	require.NoError(t, err, "parse conflicting launchpad YAML")
+
+	err = conflictingProduct.Apply(true, true, 3, true)
+	require.Error(t, err, "a pod CIDR overlapping the swarm pool must fail while no swarm exists")
+	assert.Contains(t, err.Error(), "overlaps with the Swarm overlay address pool",
+		"failure must name the overlap rather than surface as something else")
+
+	// ── Step 2: configuring a pool must resolve it ────────────────────────────
+	// swarm init has not run yet, so swarmInstallFlags is still the pool that
+	// will be applied -- which is exactly why this is the one situation where
+	// launchpad's suggested remedy works.
+	installYAML, err := setSwarmPoolAndPodCIDR(baseYAML, poolOutsideVPC, podCIDRConflictingWithDefault)
+	require.NoError(t, err, "inject pool and pod CIDR")
+
+	installProduct, err := config.ProductFromYAML([]byte(installYAML))
+	require.NoError(t, err, "parse install launchpad YAML")
+
+	installLogs := captureLaunchpadLogs(t, func() {
+		err = installProduct.Apply(true, true, 3, true)
+	})
+	require.NoError(t, err, "configuring a non-overlapping pool must allow the install to proceed")
+	assert.NotContains(t, installLogs, "of the existing swarm",
+		"a fresh install has no existing swarm to report against")
+
+	// ── Step 3: the configured pool must actually be in force ────────────────
+	// GatherFacts only reads the pool when a swarm already exists, so this
+	// second apply is what observes the result of step 2. Anything other than
+	// poolOutsideVPC here means swarm init ignored the flag.
+	verifyProduct, err := config.ProductFromYAML([]byte(installYAML))
+	require.NoError(t, err, "re-parse install launchpad YAML")
+
+	verifyLogs := captureLaunchpadLogs(t, func() {
+		err = verifyProduct.Apply(true, true, 3, true)
+	})
+	assert.NoError(t, err, "re-applying an unchanged config must succeed")
+
+	assert.Equal(t, []string{poolOutsideVPC}, discoveredAddrPool(t, verifyProduct),
+		"swarm init must have applied the configured pool")
+	assert.NotContains(t, verifyLogs, "has no effect here",
+		"config matches the running swarm, so nothing has diverged")
+	assert.NotContains(t, verifyLogs, "overlaps the overlay address pool",
+		"the configured pool does not overlap the pod CIDR")
+
+	if err = verifyProduct.Reset(); err != nil {
+		t.Logf("WARN: product.Reset() failed (non-fatal): %v", err)
+	}
+}
+
+// provisionSwarmPoolStack brings up infrastructure and returns the generated
+// cluster YAML. Teardown is registered before apply so it still runs when a
+// later require() aborts the test.
+func provisionSwarmPoolStack(t *testing.T, cfg smokeConfig) string {
+	t.Helper()
+
+	name := fmt.Sprintf("smoke-%s-%s", cfg.Name, test.GenerateRandomAlphaNumericString(5))
+
+	ngKeys := make([]string, 0, len(cfg.Nodegroups))
+	for k := range cfg.Nodegroups {
+		ngKeys = append(ngKeys, k)
+	}
+
+	vars := map[string]interface{}{
+		"name": name,
+		"aws":  awsConfig,
+		"launchpad": map[string]interface{}{
+			"drain":       false,
+			"mcr_channel": cfg.MCRChannel,
+			"mke_version": cfg.MKEVersion,
+			"msr_version": cfg.MSRVersion,
+			"mke_connect": map[string]interface{}{
+				"username": "admin",
+				"password": test.GenerateRandomAlphaNumericString(12),
+				"insecure": true,
+			},
+		},
+		"network": networkConfig,
+		"subnets": map[string]interface{}{
+			"main": map[string]interface{}{
+				"cidr":       "172.31.0.0/17",
+				"private":    false,
+				"nodegroups": ngKeys,
+			},
+		},
+		"ssh_pk_location":   t.TempDir(),
+		"nodegroups":        cfg.Nodegroups,
+		"ssh_key_algorithm": cfg.SSHKeyAlgorithm,
+		"extra_tags": map[string]string{
+			"launchpad-smoke-test":      "true",
+			"launchpad-smoke-test-name": cfg.Name,
+		},
+	}
+
+	options := terraform.Options{
+		TerraformDir: "../../examples/terraform/aws-simple",
+		Vars:         vars,
+	}
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &options)
+
+	// Registered before apply so a partial apply is still torn down, and via
+	// t.Cleanup so it survives the runtime.Goexit that require() triggers.
+	// Cleanups are LIFO, so the console capture registered next runs first,
+	// while the instances still exist.
+	t.Cleanup(func() { terraform.Destroy(t, terraformOptions) })
+	t.Cleanup(func() { dumpConsoleOutputOnFailure(t, name) })
+
+	if _, err := terraform.InitAndApplyE(t, terraformOptions); err != nil {
+		t.Fatal(err)
+	}
+
+	return terraform.Output(t, terraformOptions, "launchpad_yaml")
+}
+
+// setSwarmPoolAndPodCIDR rewrites spec.mcr.swarmInstallFlags and
+// spec.mke.installFlags. An empty value leaves that setting alone. The document
+// is round-tripped through a generic map, as bumpVersions does, so
+// infrastructure values the Terraform module injected survive untouched.
+func setSwarmPoolAndPodCIDR(yamlStr, addrPool, podCIDR string) (string, error) {
+	var doc map[interface{}]interface{}
+	if err := yaml.Unmarshal([]byte(yamlStr), &doc); err != nil {
+		return "", fmt.Errorf("unmarshal cluster YAML: %w", err)
+	}
+
+	spec, ok := doc["spec"].(map[interface{}]interface{})
+	if !ok {
+		return "", fmt.Errorf("cluster YAML missing spec")
+	}
+
+	if addrPool != "" {
+		mcr, ok := spec["mcr"].(map[interface{}]interface{})
+		if !ok {
+			mcr = map[interface{}]interface{}{}
+			spec["mcr"] = mcr
+		}
+		mcr["swarmInstallFlags"] = []interface{}{"--default-addr-pool=" + addrPool}
+	}
+
+	if podCIDR != "" {
+		mkeSpec, ok := spec["mke"].(map[interface{}]interface{})
+		if !ok {
+			return "", fmt.Errorf("cluster YAML missing spec.mke")
+		}
+
+		// Drop any --pod-cidr the module already set, so the value under test is
+		// unambiguous rather than appended alongside another one.
+		existing, _ := mkeSpec["installFlags"].([]interface{})
+		flags := make([]interface{}, 0, len(existing)+1)
+		for _, f := range existing {
+			if s, ok := f.(string); ok && strings.HasPrefix(s, "--pod-cidr") {
+				continue
+			}
+			flags = append(flags, f)
+		}
+		mkeSpec["installFlags"] = append(flags, "--pod-cidr="+podCIDR)
+	}
+
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		return "", fmt.Errorf("re-marshal cluster YAML: %w", err)
+	}
+
+	return string(out), nil
+}
+
+// discoveredAddrPool returns the pool GatherFacts read from the swarm leader.
+// It is empty unless a swarm existed when the apply started.
+func discoveredAddrPool(t *testing.T, p product.Product) []string {
+	t.Helper()
+
+	mkeProduct, ok := p.(*mke.MKE)
+	require.True(t, ok, "expected an MKE product, got %T", p)
+	require.NotNil(t, mkeProduct.ClusterConfig.Spec.MCR.Metadata, "MCR metadata must be populated")
+
+	return mkeProduct.ClusterConfig.Spec.MCR.Metadata.SwarmDefaultAddrPool
+}
+
+// captureLaunchpadLogs collects what fn logs while leaving the original output
+// in place, so CI still shows the apply as it happens.
+func captureLaunchpadLogs(t *testing.T, fn func()) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	logger := logrus.StandardLogger()
+	original := logger.Out
+	logger.SetOutput(io.MultiWriter(original, &buf))
+
+	t.Cleanup(func() { logger.SetOutput(original) })
+
+	fn()
+
+	return buf.String()
+}
+
+// assertExistingSwarmPoolBehaviour checks the contract that applies once a swarm
+// exists: the configured pool is inert and said to be, an overlap with the live
+// pool is reported, and neither condition fails the run.
+func assertExistingSwarmPoolBehaviour(t *testing.T, p product.Product, logs string) {
+	t.Helper()
+
+	assert.Contains(t, logs, "--default-addr-pool "+poolOutsideVPC,
+		"a configured pool the running swarm does not use must be reported, naming both values")
+	assert.Contains(t, logs, "has no effect here",
+		"the report must state that the setting does nothing here")
+
+	assert.Contains(t, logs, "overlaps the overlay address pool "+swarm.DefaultAddrPoolFallback+" of the existing swarm",
+		"the overlap must be reported against the live pool, not the configured one")
+
+	// The warning above claims the configured pool was not applied. Confirm that
+	// is true rather than trusting the message.
+	assert.Equal(t, []string{swarm.DefaultAddrPoolFallback}, discoveredAddrPool(t, p),
+		"the running swarm must still use the pool it was created with")
+}

--- a/test/smoke/upgrade_test.go
+++ b/test/smoke/upgrade_test.go
@@ -132,13 +132,27 @@ func runUpgradeTest(t *testing.T, cfg upgradeConfig) {
 	require.NoError(t, err, "mutate YAML for upgrade")
 
 	// ── Step 3: upgrade ───────────────────────────────────────────────────────
+	// PRODENG-3642: this is the only place CI runs launchpad against a swarm that
+	// predates the run, so the existing-swarm pool behaviour is asserted here.
+	// Both injected settings are inert on an existing cluster -- InitSwarm
+	// discards swarmInstallFlags once a swarm exists, and UpgradeMKE passes
+	// spec.mke.upgradeFlags rather than installFlags -- so this declares the
+	// customer's conflicting configuration without creating the network
+	// condition the pod CIDR check exists to prevent.
+	upgradeYAML, err = setSwarmPoolAndPodCIDR(upgradeYAML, poolOutsideVPC, podCIDRConflictingWithDefault)
+	require.NoError(t, err, "inject swarm pool and pod CIDR")
+
 	t.Logf("upgrading to: MCR %s / MKE %s", cfg.UpgradeMCRChannel, cfg.UpgradeMKEVersion)
 
 	upgradeProduct, err := config.ProductFromYAML([]byte(upgradeYAML))
 	require.NoError(t, err, "parse upgrade launchpad YAML")
 
-	err = upgradeProduct.Apply(true, true, 3, true)
-	assert.NoError(t, err, "upgrade Apply()")
+	upgradeLogs := captureLaunchpadLogs(t, func() {
+		err = upgradeProduct.Apply(true, true, 3, true)
+	})
+	assert.NoError(t, err, "upgrade Apply() must not fail over a pool conflict it cannot fix")
+
+	assertExistingSwarmPoolBehaviour(t, upgradeProduct, upgradeLogs)
 
 	// ── Step 4: reset (best-effort) ───────────────────────────────────────────
 	// See smoke_test.go for rationale on non-fatal Reset().


### PR DESCRIPTION
## What
Validate `--pod-cidr` against an existing swarm's live overlay pool instead of `spec.mcr.swarmInstallFlags`.

## Why
The pool is fixed at `swarm init` and `InitSwarm` discards those flags, so setting `--default-addr-pool` — what the overlap error recommends — silenced the check while the live overlap remained.

## How
- `swarm.DefaultAddrPool` reads pool and swarm state in one `docker info`
- `GatherFacts` stores it; `ValidateFacts` prefers it over config
- Live overlap warns; new-install overlap still fails
- Divergent configured pool reported with both values
- Docs: immutability, reading the pool, change procedure

## Testing
- `make unit-test` green; 10 pre-existing pod CIDR tests unchanged
- Immutability verified on MCR 29.1.3 — `swarm update` rejects the flag
- Parser tests use output captured from MCR 29.1.3
- Smoke coverage for the install and upgrade paths is being added on this branch; the upgrade harness applies twice against one cluster, so the second apply does run against a pre-existing swarm. The deliberate-overlap case stays opt-in, since an overlap can break host networking by design.

## Links
- JIRA: [PRODENG-3642](https://mirantis.jira.com/browse/PRODENG-3642)

## Checklist
- [x] Tests added or updated
- [x] Docs updated if user-visible behaviour changed
- [x] No debug output or dead code left in

Written by AI: claude-opus-5


[PRODENG-3642]: https://mirantis.jira.com/browse/PRODENG-3642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
