### PR TITLE
[PRODENG-3673] Bump Go to 1.26.7, align smoke-fips workflow job

### DIFF
--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -98,9 +98,16 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'smoke-fips')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
       - name: Run FIPS smoke test
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Mirantis/launchpad
 
-go 1.26.0
+go 1.26.7
 
 require (
 	al.essio.dev/pkg/shellescape v1.6.0


### PR DESCRIPTION
## What
Bump the go.mod toolchain floor to the current Go 1.26 patch and align the smoke-fips CI job with the other smoke jobs.

## Why
go.mod pinned go 1.26.0; 1.26.6/1.26.7 carry security fixes to the go command, crypto/tls, encoding/asn1, encoding/xml, html/template, net, and net/http that CI was not picking up. smoke-fips also ran actions/checkout@v4 and hashicorp/setup-terraform@v3 with no Go setup step at all, unlike every other smoke job.

## How
- go.mod: go directive 1.26.0 -> 1.26.7
- smoke-tests.yaml: smoke-fips now uses actions/checkout@v7, adds the missing actions/setup-go@v7 (go-version-file, cache), and hashicorp/setup-terraform@v4 with terraform_wrapper: false, matching smoke-modern/legacy/windows/upgrade/swarm-pool

## Testing
- go build ./... verified clean under the bumped go directive
- YAML structurally validated for the smoke-fips job

## Links
- JIRA: [PRODENG-3673](https://mirantis.jira.com/browse/PRODENG-3673)

## Checklist
- [ ] Tests added or updated
- [x] Docs updated if user-visible behaviour changed
- [x] No debug output or dead code left in

Written by AI: claude-sonnet-5

[PRODENG-3673]: https://mirantis.jira.com/browse/PRODENG-3673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ