### PR TITLE
[PRODENG-3674] Remediate Aikido SAST findings on launchpad repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@
 name: Build and Test
 permissions:
   contents: read
-  packages: write  # Required for uploading artifacts
 
 on:
   push:
@@ -19,10 +18,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
           cache: true
@@ -43,7 +44,7 @@ jobs:
           done
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: launchpad-binaries
           path: dist/
@@ -57,10 +58,12 @@ jobs:
     needs: build
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/cleanup-stale-vpcs.yaml
+++ b/.github/workflows/cleanup-stale-vpcs.yaml
@@ -38,7 +38,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Delete stale VPCs
         env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,10 +20,12 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
 
     - name: Set up Go
-      uses: actions/setup-go@v7
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
       with:
         go-version-file: go.mod
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,10 +30,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
           cache: true
@@ -49,10 +51,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
           cache: true
@@ -68,10 +72,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
           cache: true
@@ -89,10 +95,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@
 name: Release
 permissions:
   contents: read  # Top-level: Restricts all jobs by default
-  packages: write  # Required for uploading artifacts
 
 on:
   push:
@@ -20,10 +19,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
 
@@ -48,7 +49,7 @@ jobs:
           sha256sum launchpad_* > checksums.sha256
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: launchpad-release-binaries
           path: dist/
@@ -61,13 +62,13 @@ jobs:
       contents: write
     steps:
       - name: Download binaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: launchpad-release-binaries
           path: dist/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           files: dist/*
           generate_release_notes: true

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -26,14 +26,16 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'smoke-modern')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
           cache: true
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_wrapper: false
       - name: Run modern smoke test
@@ -50,14 +52,16 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'smoke-legacy')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
           cache: true
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_wrapper: false
       - name: Run legacy smoke test
@@ -74,14 +78,16 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'smoke-windows')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
           cache: true
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_wrapper: false
       - name: Run windows smoke test
@@ -98,14 +104,16 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'smoke-fips')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
           cache: true
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_wrapper: false
       - name: Run FIPS smoke test
@@ -122,14 +130,16 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'smoke-upgrade')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
           cache: true
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_wrapper: false
       - name: Run upgrade smoke test
@@ -146,14 +156,16 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'smoke-swarm-pool')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
           cache: true
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_wrapper: false
       - name: Run swarm address pool smoke test

--- a/pkg/docker/hub/hub.go
+++ b/pkg/docker/hub/hub.go
@@ -35,8 +35,7 @@ func LatestTag(org, image string, pre bool) (string, error) {
 	}
 
 	req.Header.Set("Accept", "application/json")
-	// url is from config / Docker Hub API (trusted source)
-	res, err := client.Do(req) // #nosec G704
+	res, err := client.Do(req) // #nosec G107 G704 -- url is from config / Docker Hub API (trusted source)
 	if err != nil {
 		return "", fmt.Errorf("%w: %w", errQueryFailed, err)
 	}

--- a/pkg/kubeclient/kubeclient.go
+++ b/pkg/kubeclient/kubeclient.go
@@ -33,7 +33,7 @@ type KubeClient struct {
 func NewFromBundle(bundleDir, namespace string) (*KubeClient, error) {
 	f := filepath.Join(bundleDir, constant.KubeConfigFile)
 
-	configBytes, err := os.ReadFile(f)
+	configBytes, err := os.ReadFile(f) // #nosec G304 G703 -- f is joined from a caller-supplied trusted bundle dir
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %q: %w", f, err)
 	}

--- a/pkg/mke/mke.go
+++ b/pkg/mke/mke.go
@@ -102,7 +102,7 @@ func GetClientBundle(mkeURL *url.URL, tlsConfig *tls.Config, username, password 
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-	resp, err := client.Do(req) // #nosec G704 -- URL is from cluster config/trusted MKE API
+	resp, err := client.Do(req) // #nosec G107 G704 -- URL is from cluster config/trusted MKE API
 	if err != nil {
 		log.Debugf("Failed to get bundle: %v", err)
 		return nil, fmt.Errorf("failed to request client bundle: %w", err)

--- a/pkg/product/mke/phase/remove_nodes.go
+++ b/pkg/product/mke/phase/remove_nodes.go
@@ -298,8 +298,7 @@ func (p *RemoveNodes) getReplicaIDFromHostname(config *mkeconfig.ClusterConfig, 
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-	// mkeURL from cluster config (trusted source)
-	resp, err := client.Do(req) // #nosec G704
+	resp, err := client.Do(req) // #nosec G107 G704 -- mkeURL from cluster config (trusted source)
 	if err != nil {
 		return "", fmt.Errorf("%w: failed to get containers from MKE: %w", errGetReplicaID, err)
 	}

--- a/pkg/product/mke/phase/validate_mke_health.go
+++ b/pkg/product/mke/phase/validate_mke_health.go
@@ -108,8 +108,7 @@ func checkMKENodesReady(mkeURL *url.URL, tlsConfig *tls.Config, username, passwo
 		return fmt.Errorf("failed to create request for %s: %w", mkeURL.String(), err)
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-	// mkeURL from cluster config (trusted source)
-	resp, err := client.Do(req) // #nosec G704
+	resp, err := client.Do(req) // #nosec G107 G704 -- mkeURL from cluster config (trusted source)
 	if err != nil {
 		log.Debugf("Failed to get response from %s (%d): %v", mkeURL.String(), resp.StatusCode, err)
 		return fmt.Errorf("failed to get response from %s: %w", mkeURL.String(), err)

--- a/pkg/util/fileutil/fileutil.go
+++ b/pkg/util/fileutil/fileutil.go
@@ -14,7 +14,7 @@ var LoadExternalFile = func(path string) ([]byte, error) {
 		return []byte{}, fmt.Errorf("failed to expand home dir: %w", err)
 	}
 
-	filedata, err := os.ReadFile(realpath)
+	filedata, err := os.ReadFile(realpath) // #nosec G304 G703 -- path is user-provided by design (CLI/config file reference)
 	if err != nil {
 		return []byte{}, fmt.Errorf("failed to read %q: %w", realpath, err)
 	}

--- a/pkg/util/installutil/installutil.go
+++ b/pkg/util/installutil/installutil.go
@@ -9,7 +9,7 @@ import (
 // SetupLicenseFile reads the license file and returns a license string command
 // flag to be used with MSR and MKE installers.
 func SetupLicenseFile(licenseFilePath string) (string, error) {
-	license, err := os.ReadFile(licenseFilePath)
+	license, err := os.ReadFile(licenseFilePath) // #nosec G304 G703 -- path is user-provided by design (CLI flag)
 	if err != nil {
 		return "", fmt.Errorf("failed to read license file: %w", err)
 	}


### PR DESCRIPTION
## What
Remediate the actionable Aikido SAST findings on Mirantis/launchpad: unpinned GitHub Actions, checkout credential persistence, an unused workflow permission, and two gosec suppression gaps.

## Why
Aikido flagged 5 high / 8 medium / 11 low findings (24 total, no criticals - prior critical/high open-source CVEs were already resolved by current dependency versions). 16 of the 24 are fixable in code; the remaining 8 leaked_secret findings are stale/false-positive and are documented on the ticket for manual dismissal (the available Aikido credential is read-only).

## How
- Pin every GitHub Action to a commit SHA (with version comment) across all 6 workflow files
- Add persist-credentials: false to all 15 actions/checkout steps
- Drop the unused packages: write top-level permission from build.yml/release.yml (neither job touches GitHub Packages)
- Add #nosec G304 G703 to 3 by-design os.ReadFile(<caller path>) sites
- Extend 4 existing #nosec G704-only SSRF suppressions to also cover G107, which Aikido's SAST reports under and the taint-only ID never suppressed

## Testing
- go build ./..., go vet, golangci-lint run: 0 issues on every touched package
- YAML structurally validated for all 6 workflow files

## Links
- JIRA: [PRODENG-3674](https://mirantis.jira.com/browse/PRODENG-3674)

## Checklist
- [ ] Tests added or updated
- [x] Docs updated if user-visible behaviour changed
- [x] No debug output or dead code left in

Written by AI: claude-sonnet-5

[PRODENG-3674]: https://mirantis.jira.com/browse/PRODENG-3674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ